### PR TITLE
Add a note about steps to take for already ID'd photos

### DIFF
--- a/OpenOversight/app/templates/submit_image.html
+++ b/OpenOversight/app/templates/submit_image.html
@@ -12,83 +12,88 @@
 {% block content %}
 <div class="container theme-showcase" role="main">
 
-   <div class="page-header">
-      <h1>Submit images <small>of officers in uniform. Officer faces should be clearly visible in each photograph. It is preferred if the name and/or badge number is also visible. </small></h1>
-   </div>
+    <div class="page-header">
+        <h1>Submit images <small>of officers in uniform. Officer faces should be clearly visible in each photograph. It is preferred if the name and/or badge number is also visible. </small></h1>
+    </div>
 
-   <div class="header">
-      <h3>What happens when I submit a photograph?</h3>
-      <p>The next step after a photograph of an officer has been submitted is to match it to the correct badge number, name, and OpenOversight ID (a unique identifier in our system). Volunteers <a href="{{ url_for('main.get_started_labeling') }}">sort through submitted images</a> by first confirming that officers are present in each photograph, and then by matching each photograph to the officer it depicts.</p>
-      {% if not current_user.get_id() %}
-        <p>Please consider creating an account and logging in so that we can keep track of the images you've submitted and contact you with any questions.</p>
-      {% else %}
-        <p>Your user ID will be attached to all photo submissions while you are signed in.</p>
-      {% endif %}
-   </div>
-   <h3>Select the department that the police officer in your image belongs to:</h3>
-   <div class="form-group">
-      <form class="form" name = "deptselect" id = "deptselect" method="post" role="form" label="deptselect">
-         {{ wtf.form_field(form.department) }}
-      </form>
-      <br>
-   </div>
+    <div class="header">
+        <h3>What happens when I submit a photograph?</h3>
+        <p>The next step after a photograph of an officer has been submitted is to match it to the correct badge number, name, and OpenOversight ID (a unique identifier in our system). Volunteers <a href="{{ url_for('main.get_started_labeling') }}">sort through submitted images</a> by first confirming that officers are present in each photograph, and then by matching each photograph to the officer it depicts.</p>
+        <h3>Associations</h3>
+        {% if not current_user.get_id() %}
+            <p>Please consider creating an account and logging in so that we can keep track of the images you've submitted and contact you with any questions.</p>
+        {% else %}
+            <p>Your user ID will be attached to all photo submissions while you are signed in.</p>
+        {% endif %}
+        <div class="img-rounded alert-warning">
+            <h3 class="text-black">⚠️ Already ID'd photographs ⚠️</h3>
+            <p>If you have already ID'd an officer with a photo, please submit it to <a href="https://twitter.com/TechBlocSEA" target="_blank" rel="noopener noreferrer">TechBlocSEA</a> on Twitter or via our email address (<a href="mailto:techblocsea@protonmail.com">techblocsea@protonmail.com</a>) with notes about the ID'd officers. We are working on a system for adding notes while uploading, but for the time being this is the best way to make sure we're not duplicating efforts.</p>
+        </div>
+    </div>
+    <h3>Select the department that the police officer in your image belongs to:</h3>
+    <div class="form-group">
+        <form class="form" name = "deptselect" id = "deptselect" method="post" role="form" label="deptselect">
+            {{ wtf.form_field(form.department) }}
+        </form>
+        <br>
+    </div>
 
-   <h3>Drop images here to submit photos of officers:</h3>
+    <h3>Drop images here to submit photos of officers:</h3>
 
-   <form id="my-cop-dropzone" action="/upload/department/1" class='dropzone'>
-   </form>
-   <p>Drag photographs from your computer directly into the box above or click the box to launch a finder window. If you are on mobile, you can click the box above to select pictures from your photo library or camera roll.</p>
+    <form id="my-cop-dropzone" action="/upload/department/1" class='dropzone'>
+    </form>
+    <p>Drag photographs from your computer directly into the box above or click the box to launch a finder window. If you are on mobile, you can click the box above to select pictures from your photo library or camera roll.</p>
 
-   <script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
-   <script src="{{ url_for('static', filename='js/dropzone.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/dropzone.js') }}"></script>
 
-   <script>
-   // Select user's preferred department by default
-   document.getElementById("department").selectedIndex = {{preferred_dept_id}} - 1;
-   // Save the preferred department in dept_id
-   var dept_id = document.getElementById("department").selectedIndex + 1;
-   var csrf_token = "{{ csrf_token() }}";
+    <script>
+        // Select user's preferred department by default
+        document.getElementById("department").selectedIndex = {{preferred_dept_id}} - 1;
+        // Save the preferred department in dept_id
+        var dept_id = document.getElementById("department").selectedIndex + 1;
+        var csrf_token = "{{ csrf_token() }}";
 
-   // Store changes in drop down list in dept_id variable
-   $(function() {
-      select_dept = $('#deptselect');
-      select_dept.on('change', function() {
-         // fires when department selection changes
-         dept_id = document.getElementById("department").value;
-      });
-   });
+        // Store changes in drop down list in dept_id variable
+        $(function() {
+            select_dept = $('#deptselect');
+            select_dept.on('change', function() {
+                // fires when department selection changes
+                dept_id = document.getElementById("department").value;
+            });
+        });
 
-   Dropzone.autoDiscover = false;
-   const getURL = (file) => {
-      return "/upload/department/" + dept_id;
-   }
+        Dropzone.autoDiscover = false;
+        const getURL = (file) => {
+            return "/upload/department/" + dept_id;
+        }
 
-   let myDropzone = new Dropzone("#my-cop-dropzone", {
-      method: "post",
-      url: getURL,
-      uploadMultiple: false,
-      parallelUploads: 50,
-      acceptedFiles: "image/png, image/jpeg, image/gif, image/jpg, image/webp",
-      maxFiles: 50,
-      headers: {
-        'X-CSRF-TOKEN': csrf_token
-      },
-      init: function() {
-         this.on("error", function(file, responseText) {
-            file.previewTemplate.appendChild(document.createTextNode(responseText));
-         });
-      }
-   });
-   </script>
+        let myDropzone = new Dropzone("#my-cop-dropzone", {
+            method: "post",
+            url: getURL,
+            uploadMultiple: false,
+            parallelUploads: 50,
+            acceptedFiles: "image/png, image/jpeg, image/gif, image/jpg, image/webp",
+            maxFiles: 50,
+            headers: {
+                'X-CSRF-TOKEN': csrf_token
+            },
+            init: function() {
+                this.on("error", function(file, responseText) {
+                    file.previewTemplate.appendChild(document.createTextNode(responseText));
+                });
+            }
+        });
+    </script>
 </div>
 
 <div class="container">
-   <h3>High Security Submissions</h3>
-   <p>
-      We do not log unique identifying information of visitors to our website, but if you have privacy concerns in submitting photographs,
-      we recommend using <a href="https://www.torproject.org/projects/torbrowser.html.en" rel="noopener noreferrer" target="_blank">Tor Browser.</a>
-      <strong>We automatically remove <a href="https://en.wikipedia.org/wiki/Exif" rel="noopener noreferrer" target="_blank">EXIF image data</a> from uploaded images.</strong>
-   </p>
+    <h3>High Security Submissions</h3>
+    <p>
+        We do not log unique identifying information of visitors to our website, but if you have privacy concerns in submitting photographs,
+        we recommend using <a href="https://www.torproject.org/projects/torbrowser.html.en" rel="noopener noreferrer" target="_blank">Tor Browser.</a>
+        <strong>We automatically remove <a href="https://en.wikipedia.org/wiki/Exif" rel="noopener noreferrer" target="_blank">EXIF image data</a> from uploaded images.</strong>
+    </p>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
## Description of Changes

Resolves #44

This adds a note to tell people they should send images that are already ID'd to our other socials with notes on the officers in the photos. We don't currently have a mechanism for attaching notes to the photos while a user is uploading them, so we don't want people to submit ID'd photos and have us go through the effort of re-IDing them.

## Notes for Deployment

## Screenshots (if appropriate)
![signal-2021-09-01-160100_001](https://user-images.githubusercontent.com/10214785/131756762-305e9ddc-ffdc-4aa3-907c-5e60f1a70044.png)


## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
