### PR TITLE
Imports fix, prod docker-compose in just

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,17 @@ This repository represents the **Seattle fork** of the original project. For mor
 ## Development
 
 To run the project locally:
+1. [Install `just`](https://github.com/casey/just)
 1. Copy the sample data to the data folder mounted by the project `cp database/sample_init_data.csv data/init_data.csv`.
-1. Use the `fresh_start.sh` script to quickly build, start, and populate OpenOversight locally.
-1. Run `docker-compose up -d` and visit http://localhost:3000!
+1. Run `just fresh-start` to spin up the database and insert the initial data.
+1. Run `just up` and visit http://localhost:3000!
 
 
 ## Deployment
 
 Please see the [DEPLOY.md](/DEPLOY.md) file for deployment instructions.
+
+The same `just` commands can be used to deploy production.
+The `docker-compose-prod.yml` file defines the minimum services for running in production.
+In order to use this file, set the `IS_PROD` environment variable to `true`.
+This will run all commands using the prod docker file.

--- a/data-munging/divest_spd_links.py
+++ b/data-munging/divest_spd_links.py
@@ -56,7 +56,7 @@ def main(id_path: Path, link_path: Path, output: Path):
 @click.command()
 @click.argument("id_path", type=click.Path(exists=True, path_type=Path))
 @click.argument("link_path", type=click.Path(exists=True, path_type=Path))
-@click.argument("output", type=click.Path(exists=True, path_type=Path))
+@click.argument("output", type=click.Path(path_type=Path))
 def cli(id_path: Path, link_path: Path, output: Path):
     logging.basicConfig(
         format="[%(asctime)s - %(name)s - %(lineno)3d][%(levelname)s] %(message)s",

--- a/justfile
+++ b/justfile
@@ -1,4 +1,6 @@
-DC := "docker-compose"
+IS_PROD := env_var_or_default("IS_PROD", "")
+COMPOSE_FILE := if IS_PROD == "true" {"-f docker-compose-prod.yml "} else {""}
+DC := "docker-compose " + COMPOSE_FILE
 RUN := DC + " run --rm web"
 set dotenv-load := false
 


### PR DESCRIPTION
## Description of Changes

This PR adds a small fix for the Divest SPD links generator which prevented it from running if the output file didn't already exist.

I also added some logic so that, if the variable `IS_PROD` is set to `true`, all docker commands use the prod docker compose file. I'm hoping that this allows us to create a consistent prod experience across the board by setting that variable and having everything "just work" (haha, get it?) on prod.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
