### PR TITLE
Show ambiguity in age based on birth year

### DIFF
--- a/OpenOversight/app/templates/partials/officer_general_information.html
+++ b/OpenOversight/app/templates/partials/officer_general_information.html
@@ -36,7 +36,7 @@
                 </tr>
                 <tr>
                     <td><b>Birth Year (Age)</b></td>
-                    <td>{{ officer.birth_year }} ({{ officer.birth_year|get_age }})</td>
+                    <td>{{ officer.birth_year }} (~{{ officer.birth_year|get_age }} y/o)</td>
                 </tr>
                 <tr>
                     <td><b>First Employment Date</b></td>


### PR DESCRIPTION
## Description of Changes

Resolves #41

The age that's displayed is calculated from the birth year, and may not be entirely accurate depending on the month the officer was born. This change better conveys the ambiguity.

## Notes for Deployment

## Screenshots (if appropriate)

![ageimage](https://user-images.githubusercontent.com/10214785/132080667-2643138c-98cc-4dc8-8903-7e7066ddccdb.jpeg)

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
