### PR TITLE
Munger: First employed date

### DIFF
--- a/data-munging/first_employed_date.py
+++ b/data-munging/first_employed_date.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""
+Script to populate the first employed date field on officers.
+
+This uses the assignments.csv file which can be downloaded from from OO directly.
+"""
+import logging
+from pathlib import Path
+
+import click
+import pandas as pd
+
+
+log = logging.getLogger()
+
+
+def main(assignment_path: Path, output: Path):
+    log.info("Starting import")
+    assignments = pd.read_csv(assignment_path)
+    # Sort input CSV first by officer, then by start date (ascending).
+    # Group by officer, and grab the first row. This will have their first assignment
+    # date on record.
+    first_employed = (
+        assignments.sort_values(by=["officer id", "start date"])
+        .groupby("officer id")
+        .first()
+    )
+    # The index is now officer id, so we only need to keep the start date column.
+    # (double brackets here so the entity remains a dataframe and not a series)
+    first_employed = first_employed[["start date"]]
+    # Add the department name
+    first_employed["department_name"] = "Seattle Police Department"
+    # Rename to the fields OO is expecting
+    first_employed = first_employed.reset_index().rename(
+        {"officer id": "id", "start date": "employment_date"}, axis="columns"
+    )
+    # Save!
+    first_employed.to_csv(output, index=False)
+    log.info("Finished")
+
+
+@click.command()
+@click.argument("assignment_path", type=click.Path(exists=True, path_type=Path))
+@click.argument("output", type=click.Path(path_type=Path))
+def cli(assignment_path: Path, output: Path):
+    logging.basicConfig(
+        format="[%(asctime)s - %(name)s - %(lineno)3d][%(levelname)s] %(message)s",
+        level=logging.INFO,
+    )
+    main(assignment_path, output)
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Description of Changes

Super quick/small script to generate the "first employed date" field on officers, based on the `assignments.csv` sheet which can be downloaded from OO.

This is dependent on running the upload from #51.

## Notes for Deployment

1. Use OO to download the assignments CSV.
1. The munging can be run with `python data-munging/first_employed_date.py <Assignment-CSV> <output>`.
1. The importer can then be run with `just import --officers-csv /data/first_employed_date.csv "Seattle\ Police\ Department"`

## Screenshots (if appropriate)

![Screenshot_2021-09-08_11-08-23](https://user-images.githubusercontent.com/10214785/132561937-a24da3cd-ad12-42e1-97c0-1cfdd8b8d785.png)


## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
