### PR TITLE
Improve data download links

### DIFF
--- a/OpenOversight/app/main/downloads.py
+++ b/OpenOversight/app/main/downloads.py
@@ -13,6 +13,7 @@ from OpenOversight.app.models import (
     Assignment,
     Incident,
     Link,
+    Description,
 )
 
 T = TypeVar("T")
@@ -150,4 +151,15 @@ def links_record_maker(link: Link) -> _Record:
         "author": link.author,
         "officers": [officer.id for officer in link.officers],
         "incidents": [incident.id for incident in link.incidents],
+    }
+
+
+def descriptions_record_maker(description: Description) -> _Record:
+    return {
+        "id": description.id,
+        "text_contents": description.text_contents,
+        "creator_id": description.creator_id,
+        "officer_id": description.officer_id,
+        "date_created": description.date_created,
+        "date_updated": description.date_updated,
     }

--- a/OpenOversight/app/main/downloads.py
+++ b/OpenOversight/app/main/downloads.py
@@ -115,6 +115,7 @@ def assignment_record_maker(assignment: Assignment) -> _Record:
         "start date": assignment.star_date,
         "end date": assignment.resign_date,
         "unit id": assignment.unit and assignment.unit.id,
+        "unit description": assignment.unit and assignment.unit.descrip,
     }
 
 

--- a/OpenOversight/app/main/downloads.py
+++ b/OpenOversight/app/main/downloads.py
@@ -6,7 +6,14 @@ from typing import List, TypeVar, Callable, Dict, Any
 from flask import Response, abort
 from sqlalchemy.orm import Query
 
-from OpenOversight.app.models import Department, Salary, Officer, Assignment, Incident
+from OpenOversight.app.models import (
+    Department,
+    Salary,
+    Officer,
+    Assignment,
+    Incident,
+    Link,
+)
 
 T = TypeVar("T")
 _Record = Dict[str, Any]
@@ -130,4 +137,17 @@ def incidents_record_maker(incident: Incident) -> _Record:
         "licenses": " ".join(map(str, incident.license_plates)),
         "links": " ".join(map(str, incident.links)),
         "officers": " ".join(map(str, incident.officers)),
+    }
+
+
+def links_record_maker(link: Link) -> _Record:
+    return {
+        "id": link.id,
+        "title": link.title,
+        "url": link.url,
+        "link_type": link.link_type,
+        "description": link.description,
+        "author": link.author,
+        "officers": [officer.id for officer in link.officers],
+        "incidents": [incident.id for incident in link.incidents],
     }

--- a/OpenOversight/app/main/downloads.py
+++ b/OpenOversight/app/main/downloads.py
@@ -1,0 +1,132 @@
+import csv
+import io
+from datetime import date
+from typing import List, TypeVar, Callable, Dict, Any
+
+from flask import Response, abort
+from sqlalchemy.orm import Query
+
+from OpenOversight.app.models import Department, Salary, Officer, Assignment, Incident
+
+T = TypeVar("T")
+_Record = Dict[str, Any]
+
+
+########################################################################################
+# Check util methods
+########################################################################################
+
+
+def check_output(output_str):
+    if output_str == "Not Sure":
+        return ""
+    return output_str
+
+
+########################################################################################
+# Route assistance function
+########################################################################################
+
+
+def make_downloadable_csv(
+    query: Query,
+    department_id: int,
+    csv_suffix: str,
+    field_names: List[str],
+    record_maker: Callable[[T], _Record],
+) -> Response:
+    department = Department.query.filter_by(id=department_id).first()
+    if not department:
+        abort(404)
+
+    csv_output = io.StringIO()
+    csv_writer = csv.DictWriter(csv_output, fieldnames=field_names)
+    csv_writer.writeheader()
+
+    for entity in query:
+        record = record_maker(entity)
+        csv_writer.writerow(record)
+
+    dept_name = department.name.replace(" ", "_")
+    csv_name = dept_name + f"_{csv_suffix}.csv"
+
+    csv_headers = {"Content-disposition": "attachment; filename=" + csv_name}
+    return Response(csv_output.getvalue(), mimetype="text/csv", headers=csv_headers)
+
+
+########################################################################################
+# Record makers
+########################################################################################
+
+
+def salary_record_maker(salary: Salary) -> _Record:
+    return {
+        "id": salary.id,
+        "officer id": salary.officer_id,
+        "first name": salary.officer.first_name,
+        "last name": salary.officer.last_name,
+        "salary": salary.salary,
+        "overtime_pay": salary.overtime_pay,
+        "year": salary.year,
+        "is_fiscal_year": salary.is_fiscal_year,
+    }
+
+
+def officer_record_maker(officer: Officer) -> _Record:
+    if officer.assignments_lazy:
+        most_recent_assignment = max(
+            officer.assignments_lazy, key=lambda a: a.star_date or date.min
+        )
+        most_recent_title = most_recent_assignment.job and check_output(
+            most_recent_assignment.job.job_title
+        )
+    else:
+        most_recent_assignment = None
+        most_recent_title = None
+    if officer.salaries:
+        most_recent_salary = max(officer.salaries, key=lambda s: s.year)
+    else:
+        most_recent_salary = None
+    return {
+        "id": officer.id,
+        "unique identifier": officer.unique_internal_identifier,
+        "last name": officer.last_name,
+        "first name": officer.first_name,
+        "middle initial": officer.middle_initial,
+        "suffix": officer.suffix,
+        "gender": check_output(officer.gender),
+        "race": check_output(officer.race),
+        "birth year": officer.birth_year,
+        "employment date": officer.employment_date,
+        "badge number": most_recent_assignment and most_recent_assignment.star_no,
+        "job title": most_recent_title,
+        "most recent salary": most_recent_salary and most_recent_salary.salary,
+    }
+
+
+def assignment_record_maker(assignment: Assignment) -> _Record:
+    officer = assignment.baseofficer
+    return {
+        "id": assignment.id,
+        "officer id": assignment.officer_id,
+        "officer unique identifier": officer and officer.unique_internal_identifier,
+        "badge number": assignment.star_no,
+        "job title": assignment.job and check_output(assignment.job.job_title),
+        "start date": assignment.star_date,
+        "end date": assignment.resign_date,
+        "unit id": assignment.unit and assignment.unit.id,
+    }
+
+
+def incidents_record_maker(incident: Incident) -> _Record:
+    return {
+        "id": incident.id,
+        "report_num": incident.report_number,
+        "date": incident.date,
+        "time": incident.time,
+        "description": incident.description,
+        "location": incident.address,
+        "licenses": " ".join(map(str, incident.license_plates)),
+        "links": " ".join(map(str, incident.links)),
+        "officers": " ".join(map(str, incident.officers)),
+    }

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -930,6 +930,19 @@ def download_dept_salaries_csv(department_id):
     return downloads.make_downloadable_csv(salaries, department_id, "Salaries", field_names, downloads.salary_record_maker)
 
 
+@main.route('/download/department/<int:department_id>/links', methods=['GET'])
+@limiter.limit('5/minute')
+def download_dept_links_csv(department_id):
+    links = (db.session.query(Link)
+             .join(Link.officers)
+             .filter(Officer.department_id == department_id)
+             .options(contains_eager(Link.officers))
+             )
+
+    field_names = ["id", "title", "url", "link_type", "description", "author", "officers", "incidents"]
+    return downloads.make_downloadable_csv(links, department_id, "Links", field_names, downloads.links_record_maker)
+
+
 @sitemap_include
 @main.route('/download/all', methods=['GET'])
 def all_data():

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -943,6 +943,19 @@ def download_dept_links_csv(department_id):
     return downloads.make_downloadable_csv(links, department_id, "Links", field_names, downloads.links_record_maker)
 
 
+@main.route('/download/department/<int:department_id>/descriptions', methods=['GET'])
+@limiter.limit('5/minute')
+def download_dept_descriptions_csv(department_id):
+    notes = (db.session.query(Description)
+             .join(Description.officer)
+             .filter(Officer.department_id == department_id)
+             .options(contains_eager(Description.officer))
+             )
+
+    field_names = ["id", "text_contents", "creator_id", "officer_id", "date_created", "date_updated"]
+    return downloads.make_downloadable_csv(notes, department_id, "Notes", field_names, downloads.descriptions_record_maker)
+
+
 @sitemap_include
 @main.route('/download/all', methods=['GET'])
 def all_data():

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1,6 +1,3 @@
-import csv
-from datetime import date
-import io
 import os
 import re
 from sqlalchemy.exc import IntegrityError
@@ -10,10 +7,10 @@ import sys
 from traceback import format_exc
 
 from flask import (abort, render_template, request, redirect, url_for,
-                   flash, current_app, jsonify, Response)
+                   flash, current_app, jsonify)
 from flask_login import current_user, login_required, login_user
 
-from . import main
+from . import main, downloads
 from .. import limiter, sitemap
 from ..utils import (serve_image, compute_leaderboard_stats, get_random_image,
                      allowed_file, add_new_assignment, edit_existing_assignment,
@@ -881,63 +878,9 @@ def submit_data():
         return render_template('submit_image.html', form=form, preferred_dept_id=preferred_dept_id)
 
 
-def check_input(str_input):
-    if str_input is None or str_input == "Not Sure":
-        return ""
-    else:
-        return str(str_input).replace(",", " ")  # no commas allowed
-
-
-@main.route('/download/department/<int:department_id>', methods=['GET'])
-@limiter.limit('5/minute')
-def deprecated_download_dept_csv(department_id):
-    department = Department.query.filter_by(id=department_id).first()
-    records = Officer.query.filter_by(department_id=department_id).all()
-    if not department or not records:
-        abort(404)
-    dept_name = records[0].department.name.replace(" ", "_")
-    first_row = "id, last, first, middle, suffix, gender, "\
-                "race, born, employment_date, assignments\n"
-
-    assign_dict = {}
-    assign_records = Assignment.query.all()
-    for r in assign_records:
-        if r.officer_id not in assign_dict:
-            assign_dict[r.officer_id] = []
-        assign_dict[r.officer_id].append("(#%s %s %s %s %s)" % (check_input(r.star_no), check_input(r.job_id), check_input(r.unit_id), check_input(r.star_date), check_input(r.resign_date)))
-
-    record_list = ["%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n" %
-                   (str(record.id),
-                    check_input(record.last_name),
-                    check_input(record.first_name),
-                    check_input(record.middle_initial),
-                    check_input(record.suffix),
-                    check_input(record.gender),
-                    check_input(record.race),
-                    check_input(record.birth_year),
-                    check_input(record.employment_date),
-                    " ".join(assign_dict.get(record.id, [])),
-                    ) for record in records]
-
-    csv_name = dept_name + "_Officers.csv"
-    csv = first_row + "".join(record_list)
-    csv_headers = {"Content-disposition": "attachment; filename=" + csv_name}
-    return Response(csv, mimetype="text/csv", headers=csv_headers)
-
-
-def check_output(output_str):
-    if output_str == "Not Sure":
-        return ""
-    return output_str
-
-
 @main.route('/download/department/<int:department_id>/officers', methods=['GET'])
 @limiter.limit('5/minute')
 def download_dept_officers_csv(department_id):
-    department = Department.query.filter_by(id=department_id).first()
-    if not department:
-        abort(404)
-
     officers = (db.session.query(Officer)
                 .options(joinedload(Officer.assignments_lazy)
                          .joinedload(Assignment.job)
@@ -946,56 +889,14 @@ def download_dept_officers_csv(department_id):
                 .filter_by(department_id=department_id)
                 )
 
-    if not officers:
-        abort(404)
-    csv_output = io.StringIO()
-    csv_fieldnames = ["id", "unique identifier", "last name", "first name", "middle initial", "suffix", "gender",
-                      "race", "birth year", "employment date", "badge number", "job title", "most recent salary"]
-    csv_writer = csv.DictWriter(csv_output, fieldnames=csv_fieldnames)
-    csv_writer.writeheader()
-
-    for officer in officers:
-        if officer.assignments_lazy:
-            most_recent_assignment = max(officer.assignments_lazy, key=lambda a: a.star_date or date.min)
-            most_recent_title = most_recent_assignment.job and check_output(most_recent_assignment.job.job_title)
-        else:
-            most_recent_assignment = None
-            most_recent_title = None
-        if officer.salaries:
-            most_recent_salary = max(officer.salaries, key=lambda s: s.year)
-        else:
-            most_recent_salary = None
-        record = {
-            "id": officer.id,
-            "unique identifier": officer.unique_internal_identifier,
-            "last name": officer.last_name,
-            "first name": officer.first_name,
-            "middle initial": officer.middle_initial,
-            "suffix": officer.suffix,
-            "gender": check_output(officer.gender),
-            "race": check_output(officer.race),
-            "birth year": officer.birth_year,
-            "employment date": officer.employment_date,
-            "badge number": most_recent_assignment and most_recent_assignment.star_no,
-            "job title": most_recent_title,
-            "most recent salary": most_recent_salary and most_recent_salary.salary,
-        }
-        csv_writer.writerow(record)
-
-    dept_name = department.name.replace(" ", "_")
-    csv_name = dept_name + "_Officers.csv"
-
-    csv_headers = {"Content-disposition": "attachment; filename=" + csv_name}
-    return Response(csv_output.getvalue(), mimetype="text/csv", headers=csv_headers)
+    field_names = ["id", "unique identifier", "last name", "first name", "middle initial", "suffix", "gender",
+                   "race", "birth year", "employment date", "badge number", "job title", "most recent salary"]
+    return downloads.make_downloadable_csv(officers, department_id, "Officers", field_names, downloads.officer_record_maker)
 
 
 @main.route('/download/department/<int:department_id>/assignments', methods=['GET'])
 @limiter.limit('5/minute')
 def download_dept_assignments_csv(department_id):
-    department = Department.query.filter_by(id=department_id).first()
-    if not department:
-        abort(404)
-
     assignments = (db.session.query(Assignment)
                    .join(Assignment.baseofficer)
                    .filter(Officer.department_id == department_id)
@@ -1004,96 +905,29 @@ def download_dept_assignments_csv(department_id):
                    .options(joinedload(Assignment.job))
                    )
 
-    csv_output = io.StringIO()
-    csv_fieldnames = ["id", "officer id", "officer unique identifier", "badge number", "job title", "start date", "end date", "unit id"]
-    csv_writer = csv.DictWriter(csv_output, fieldnames=csv_fieldnames)
-    csv_writer.writeheader()
-
-    for assignment in assignments:
-        officer = assignment.baseofficer
-        record = {
-            "id": assignment.id,
-            "officer id": assignment.officer_id,
-            "officer unique identifier": officer and officer.unique_internal_identifier,
-            "badge number": assignment.star_no,
-            "job title": assignment.job and check_output(assignment.job.job_title),
-            "start date": assignment.star_date,
-            "end date": assignment.resign_date,
-            "unit id": assignment.unit and assignment.unit.id,
-        }
-        csv_writer.writerow(record)
-
-    dept_name = department.name.replace(" ", "_")
-    csv_name = dept_name + "_Assignments.csv"
-
-    csv_headers = {"Content-disposition": "attachment; filename=" + csv_name}
-    return Response(csv_output.getvalue(), mimetype="text/csv", headers=csv_headers)
+    field_names = ["id", "officer id", "officer unique identifier", "badge number", "job title", "start date", "end date", "unit id"]
+    return downloads.make_downloadable_csv(assignments, department_id, "Assignments", field_names, downloads.assignment_record_maker)
 
 
 @main.route('/download/department/<int:department_id>/incidents', methods=['GET'])
 @limiter.limit('5/minute')
 def download_incidents_csv(department_id):
-    department = Department.query.filter_by(id=department_id).first()
-    records = Incident.query.filter_by(department_id=department.id).all()
-    if not department or not records:
-        abort(404)
-    dept_name = records[0].department.name.replace(" ", "_")
-    first_row = "id,report_num,date,time,description,location,licences,links,officers\n"
-
-    record_list = ["%s,%s,%s,%s,%s,%s,%s,%s,%s\n" %
-                   (str(record.id),
-                    check_input(record.report_number),
-                    check_input(record.date),
-                    check_input(record.time),
-                    check_input(record.description),
-                    check_input(record.address),
-                    " ".join(map(lambda x: str(x), record.license_plates)),
-                    " ".join(map(lambda x: str(x), record.links)),
-                    " ".join(map(lambda x: str(x), record.officers)),
-                    ) for record in records]
-
-    csv_name = dept_name + "_Incidents.csv"
-    csv = first_row + "".join(record_list)
-    csv_headers = {"Content-disposition": "attachment; filename=" + csv_name}
-    return Response(csv, mimetype="text/csv", headers=csv_headers)
+    incidents = Incident.query.filter_by(department_id=department_id).all()
+    field_names = ["id", "report_num", "date", "time", "description", "location", "licences", "links", "officers"]
+    return downloads.make_downloadable_csv(incidents, department_id, "Incidents", field_names, downloads.incidents_record_maker)
 
 
 @main.route('/download/department/<int:department_id>/salaries', methods=['GET'])
 @limiter.limit('5/minute')
 def download_dept_salaries_csv(department_id):
-    department = Department.query.filter_by(id=department_id).first()
-    if not department:
-        abort(404)
-
     salaries = (db.session.query(Salary)
                 .join(Salary.officer)
                 .filter(Officer.department_id == department_id)
                 .options(contains_eager(Salary.officer))
                 )
 
-    csv_output = io.StringIO()
-    csv_fieldnames = ["id", "officer id", "first name", "last name", "salary", "overtime_pay", "year", "is_fiscal_year"]
-    csv_writer = csv.DictWriter(csv_output, fieldnames=csv_fieldnames)
-    csv_writer.writeheader()
-
-    for salary in salaries:
-        record = {
-            "id": salary.id,
-            "officer id": salary.officer_id,
-            "first name": salary.officer.first_name,
-            "last name": salary.officer.last_name,
-            "salary": salary.salary,
-            "overtime_pay": salary.overtime_pay,
-            "year": salary.year,
-            "is_fiscal_year": salary.is_fiscal_year,
-        }
-        csv_writer.writerow(record)
-
-    dept_name = department.name.replace(" ", "_")
-    csv_name = dept_name + "_Salaries.csv"
-
-    csv_headers = {"Content-disposition": "attachment; filename=" + csv_name}
-    return Response(csv_output.getvalue(), mimetype="text/csv", headers=csv_headers)
+    field_names = ["id", "officer id", "first name", "last name", "salary", "overtime_pay", "year", "is_fiscal_year"]
+    return downloads.make_downloadable_csv(salaries, department_id, "Salaries", field_names, downloads.salary_record_maker)
 
 
 @sitemap_include

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -905,7 +905,7 @@ def download_dept_assignments_csv(department_id):
                    .options(joinedload(Assignment.job))
                    )
 
-    field_names = ["id", "officer id", "officer unique identifier", "badge number", "job title", "start date", "end date", "unit id"]
+    field_names = ["id", "officer id", "officer unique identifier", "badge number", "job title", "start date", "end date", "unit id", "unit description"]
     return downloads.make_downloadable_csv(assignments, department_id, "Assignments", field_names, downloads.assignment_record_maker)
 
 

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -2,7 +2,7 @@ import re
 from datetime import date
 
 from flask_sqlalchemy import SQLAlchemy
-from flask_sqlalchemy.model import DefaultMeta
+# from flask_sqlalchemy.model import DefaultMeta
 from sqlalchemy.orm import validates
 from sqlalchemy import UniqueConstraint, CheckConstraint
 from werkzeug.security import generate_password_hash, check_password_hash
@@ -15,7 +15,7 @@ from . import login_manager
 
 db = SQLAlchemy()
 
-BaseModel = db.Model  # type: DefaultMeta
+BaseModel = db.Model  # This was here before but it's fucking with my IDE's typing - type: DefaultMeta (MJSB 2021-09-08)
 
 officer_links = db.Table('officer_links',
                          db.Column('officer_id', db.Integer, db.ForeignKey('officers.id'), primary_key=True),

--- a/OpenOversight/app/templates/all_depts.html
+++ b/OpenOversight/app/templates/all_depts.html
@@ -11,6 +11,7 @@
                 <ul class="list-group">
                     <a href={{ url_for('main.download_dept_officers_csv',department_id=dept.id) }}><li class="list-group-item">officers.csv</li></a>
                     <a href={{ url_for('main.download_dept_assignments_csv',department_id=dept.id) }}><li class="list-group-item">assignments.csv</li></a>
+                    <a href={{ url_for('main.download_dept_salaries_csv',department_id=dept.id) }}><li class="list-group-item">salaries.csv</li></a>
                     {% if dept.incidents %}
                         <a href={{ url_for('main.download_incidents_csv',department_id=dept.id) }}><li class="list-group-item">incidents.csv</li></a>
                     {% endif %}

--- a/OpenOversight/app/templates/all_depts.html
+++ b/OpenOversight/app/templates/all_depts.html
@@ -2,21 +2,22 @@
 {% import "bootstrap/wtf.html" as wtf %}
 {% block content %}
 
-<div class="container theme-showcase" role="main">
+    <div class="container theme-showcase" role="main">
 
-  <!--div class="text-center frontpage-leads"-->
-  {% for dept in departments %}
-    <p>
-       {{ dept.name }}
-       <a href={{ url_for('main.download_dept_officers_csv',department_id=dept.id) }}>officers.csv</a> 
-       <a href={{ url_for('main.download_dept_assignments_csv',department_id=dept.id) }}>assignments.csv</a> 
-       {% if dept.incidents %}
-           <a href={{ url_for('main.download_incidents_csv',department_id=dept.id) }}>incidents.csv</a>
-       {% endif %}
-
-    </p>
-  {% endfor %}
-  <!--/div-->
-</div>
+        <div class="text-center frontpage-leads">
+            {% for dept in departments %}
+                <p>
+                <h2>{{ dept.name }}</h2>
+                <ul class="list-group">
+                    <a href={{ url_for('main.download_dept_officers_csv',department_id=dept.id) }}><li class="list-group-item">officers.csv</li></a>
+                    <a href={{ url_for('main.download_dept_assignments_csv',department_id=dept.id) }}><li class="list-group-item">assignments.csv</li></a>
+                    {% if dept.incidents %}
+                        <a href={{ url_for('main.download_incidents_csv',department_id=dept.id) }}><li class="list-group-item">incidents.csv</li></a>
+                    {% endif %}
+                </ul>
+                </p>
+            {% endfor %}
+        </div>
+    </div>
 
 {% endblock %}

--- a/OpenOversight/app/templates/all_depts.html
+++ b/OpenOversight/app/templates/all_depts.html
@@ -12,6 +12,7 @@
                     <a href={{ url_for('main.download_dept_officers_csv',department_id=dept.id) }}><li class="list-group-item">officers.csv</li></a>
                     <a href={{ url_for('main.download_dept_assignments_csv',department_id=dept.id) }}><li class="list-group-item">assignments.csv</li></a>
                     <a href={{ url_for('main.download_dept_salaries_csv',department_id=dept.id) }}><li class="list-group-item">salaries.csv</li></a>
+                    <a href={{ url_for('main.download_dept_links_csv',department_id=dept.id) }}><li class="list-group-item">links.csv</li></a>
                     {% if dept.incidents %}
                         <a href={{ url_for('main.download_incidents_csv',department_id=dept.id) }}><li class="list-group-item">incidents.csv</li></a>
                     {% endif %}

--- a/OpenOversight/app/templates/all_depts.html
+++ b/OpenOversight/app/templates/all_depts.html
@@ -13,6 +13,7 @@
                     <a href={{ url_for('main.download_dept_assignments_csv',department_id=dept.id) }}><li class="list-group-item">assignments.csv</li></a>
                     <a href={{ url_for('main.download_dept_salaries_csv',department_id=dept.id) }}><li class="list-group-item">salaries.csv</li></a>
                     <a href={{ url_for('main.download_dept_links_csv',department_id=dept.id) }}><li class="list-group-item">links.csv</li></a>
+                    <a href={{ url_for('main.download_dept_descriptions_csv',department_id=dept.id) }}><li class="list-group-item">descriptions.csv</li></a>
                     {% if dept.incidents %}
                         <a href={{ url_for('main.download_incidents_csv',department_id=dept.id) }}><li class="list-group-item">incidents.csv</li></a>
                     {% endif %}

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -123,12 +123,13 @@
     	</div>{# end col #}
     {% endif %}
 
-    {% if is_admin_or_coordinator %}
+    {% if officer.descriptions or is_admin_or_coordinator %}
       <div class='col-sm-12 col-md-6'>
         {% include "partials/officer_descriptions.html" %}
       </div>{# end col #}
     {% endif %}
 
+    {# Notes are for internal use #}
     {% if is_admin_or_coordinator %}
     <div class='col-sm-12 col-md-6'>
       {% include "partials/officer_notes.html" %}


### PR DESCRIPTION
## Description of Changes

Resolves #46

This PR improves the look of the data download page and adds the following sheets for download:
* Salaries
* Links
* Descriptions

The download routes were...a mess. I've moved the CSV generation functionality into a new `downloads.py` module. I'm hoping this provides clearer separation and shared functionality.

Descriptions also weren't being shown by default (only when an admin/area coordinator was logged in), so I've changed that to always show if they exist.

In a later PR, I'd like to standardize the column names (e.g. remove spaces). Since some of our mungers are dependent on the current format I'll leave it for now. Also TODO: tests (I promise I'll get to this once we're soft-launched :crossed_fingers:).

## Notes for Deployment

No static rebuild necessary :) 

## Screenshots (if appropriate)

### Before
![Screenshot_2021-09-08_16-52-42](https://user-images.githubusercontent.com/10214785/132600958-40e41534-2e6d-429d-a722-e738efb85df2.png)

### After
![Screenshot_2021-09-08_16-52-29](https://user-images.githubusercontent.com/10214785/132600967-63a1269d-0705-470a-b77c-40f70bb37b89.png)

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
