### PR TITLE
Currently on the force computed field

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -95,6 +95,13 @@ def create_app(config_name='default'):
         if birth_year:
             return int(datetime.datetime.now().year - birth_year)
 
+    @app.template_filter('currently_on_force')
+    def officer_currently_on_force(assignments):
+        if not assignments:
+            return "Uncertain"
+        most_recent = max(assignments, key=lambda x: x.star_date or datetime.date.min)
+        return "Yes" if most_recent.resign_date is None else "No"
+
     # Add commands
     Migrate(app, db, os.path.join(os.path.dirname(__file__), '..', 'migrations'))  # Adds 'db' command
     from .commands import (make_admin_user, link_images_to_department,

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -133,6 +133,8 @@ class Officer(BaseModel):
         return '{} {}'.format(self.first_name, self.last_name)
 
     def race_label(self):
+        if self.race is None:
+            return 'Data Missing'
         from .main.choices import RACE_CHOICES
         for race, label in RACE_CHOICES:
             if self.race == race:

--- a/OpenOversight/app/templates/partials/officer_general_information.html
+++ b/OpenOversight/app/templates/partials/officer_general_information.html
@@ -42,6 +42,10 @@
                     <td><b>First Employment Date</b></td>
                     <td>{{ officer.employment_date }}</td>
                 </tr>
+                <tr>
+                    <td><b>Currently on the force</b></td>
+                    <td>{{ assignments | currently_on_force }}</td>
+                </tr>
             </tbody>
         </table>
     </div>

--- a/OpenOversight/app/templates/partials/officer_general_information.html
+++ b/OpenOversight/app/templates/partials/officer_general_information.html
@@ -36,7 +36,13 @@
                 </tr>
                 <tr>
                     <td><b>Birth Year (Age)</b></td>
-                    <td>{{ officer.birth_year }} (~{{ officer.birth_year|get_age }} y/o)</td>
+                    <td>
+                        {% if officer.birth_year %}
+                        {{ officer.birth_year }} (~{{ officer.birth_year|get_age }} y/o)
+                        {% else %}
+                        Data Missing
+                        {% endif %}
+                    </td>
                 </tr>
                 <tr>
                     <td><b>First Employment Date</b></td>


### PR DESCRIPTION
## Description of Changes

This PR adds a "Currently on the force" computed field for officers based on their assignments. I've also cleaned up how fields are displayed if there is no data.

## Notes for Deployment

## Screenshots (if appropriate)

### Without data
![Screenshot_2021-09-08_17-41-57](https://user-images.githubusercontent.com/10214785/132603998-af6e1024-53ed-40ff-9c56-64255cd076e4.png)

### With data
![Screenshot_2021-09-08_17-41-48](https://user-images.githubusercontent.com/10214785/132604002-6a9536c0-b776-48ca-a34c-a9fbb00b0e34.png)

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
