### PR TITLE
Hotfix: Use relative imports

### DIFF
--- a/OpenOversight/app/main/downloads.py
+++ b/OpenOversight/app/main/downloads.py
@@ -6,7 +6,7 @@ from typing import List, TypeVar, Callable, Dict, Any
 from flask import Response, abort
 from sqlalchemy.orm import Query
 
-from OpenOversight.app.models import (
+from ..models import (
     Department,
     Salary,
     Officer,


### PR DESCRIPTION
## Description of Changes

Addendum to #54, this was working locally with absolute imports but does not appear to be working on prod as such. This PR fixes the imports so it does.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
