### PR TITLE
Bugfix: Generate static files at startup, rather than during build

### DIFF
--- a/OpenOversight/scripts/entrypoint.sh
+++ b/OpenOversight/scripts/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 if [ "${DOCKER_BUILD_ENV:-}" == "production" ]; then
+    # Compile any assets
+    npm run-script build
+    # Copy static assets into NEW folder, specifically at runtime
+    cp -R /usr/src/app/OpenOversight/app/static/* /usr/src/app/OpenOversight/static/
     gunicorn -w 4 -b 0.0.0.0:3000 app:app
 else
     yarn build

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -25,7 +25,7 @@ services:
    links:
      - postgres:postgres
    volumes:
-     - static_files:/usr/src/app/OpenOversight/app/static
+     - static_files:/usr/src/app/OpenOversight/static
      - ./data:/data/
    command: scripts/entrypoint.sh
    ports:


### PR DESCRIPTION
## Description of Changes

We have an issue with a lot of services where the static asset volume that's shared with nginx requires deletion in order to be updated. _Deletion_ requires stoping both the service container AND nginx, removing the volume, spinning up the service, then spinning up nginx. It's tedious and creates unnecessary downtime for all other services.

Thanks to [this SO question](https://stackoverflow.com/questions/61551237/dockerized-nginx-can-static-assets-be-updated-without-stopping-the-container) and a little digging, I found the issue! The Dockerfile was creating the current static folder (`OO/app/static`) at build time. I think this creates a situation where the files get loaded into the volume **once** at first startup and then never touched again. This new approach creates a completely separate directory (`OO/static`) which is **not touched at all** during build time. Then at runtime (in the `entrypoint.sh`), the build-time static files are copied into this new folder. This creates a situation where the volume is being updated at every startup, which is what we want!

I've tested that I can make a change to the static files, **only** deploy the service, and nginx will serve the new files :tada:

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
