### PR TITLE
Allow volunteers to directly upload officer images

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -965,7 +965,6 @@ def all_data():
 
 @main.route('/submit_officer_images/officer/<int:officer_id>', methods=['GET', 'POST'])
 @login_required
-@ac_or_admin_required
 def submit_officer_images(officer_id):
     officer = Officer.query.get_or_404(officer_id)
     return render_template('submit_officer_image.html', officer=officer)
@@ -979,8 +978,7 @@ def upload(department_id, officer_id=None):
         officer = Officer.query.filter_by(id=officer_id).first()
         if not officer:
             return jsonify(error='This officer does not exist.'), 404
-        if not (current_user.is_administrator or
-                (current_user.is_area_coordinator and officer.department_id == current_user.ac_department_id)):
+        if current_user.is_anonymous or current_user.ac_department_id != officer.department_id:
             return jsonify(error='You are not authorized to upload photos of this officer.'), 403
     file_to_upload = request.files['file']
     if not allowed_file(file_to_upload.filename):

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -978,7 +978,9 @@ def upload(department_id, officer_id=None):
         officer = Officer.query.filter_by(id=officer_id).first()
         if not officer:
             return jsonify(error='This officer does not exist.'), 404
-        if current_user.is_anonymous or current_user.ac_department_id != officer.department_id:
+        if current_user.is_anonymous or (
+            not current_user.is_administrator and current_user.ac_department_id != officer.department_id
+        ):
             return jsonify(error='You are not authorized to upload photos of this officer.'), 403
     file_to_upload = request.files['file']
     if not allowed_file(file_to_upload.filename):

--- a/OpenOversight/app/templates/partials/officer_add_photos.html
+++ b/OpenOversight/app/templates/partials/officer_add_photos.html
@@ -1,3 +1,3 @@
-{% if not current_user.is_anonymous and current_user.ac_department_id == officer.department_id %}
+{% if (not current_user.is_anonymous and current_user.ac_department_id == officer.department_id) or current_user.is_administrator %}
     <a class="btn btn-primary" href={{ url_for('main.submit_officer_images', officer_id=officer.id) }}>Add photos of this officer</a>
 {% endif %}

--- a/OpenOversight/app/templates/partials/officer_add_photos.html
+++ b/OpenOversight/app/templates/partials/officer_add_photos.html
@@ -1,3 +1,3 @@
-{% if is_admin_or_coordinator %}
+{% if not current_user.is_anonymous and current_user.ac_department_id == officer.department_id %}
     <a class="btn btn-primary" href={{ url_for('main.submit_officer_images', officer_id=officer.id) }}>Add photos of this officer</a>
 {% endif %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,12 @@ services:
      - minio:/data
    ports:
      - "9000:9000"
+     - "9001:9001"
    env_file:
      - .env
    environment:
      MINIO_ROOT_USER: minio
-   command: server /data
+   command: server /data --console-address ":9001"
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
@@ -40,6 +41,7 @@ services:
    # Add the desired bucket, and set its policy to public
    entrypoint: >
      /bin/sh -c "
+     sleep 5;
      /usr/bin/mc config host add myminio http://minio:9000 minio ${MINIO_ROOT_PASSWORD};
      /usr/bin/mc mb myminio/${S3_BUCKET_NAME};
      /usr/bin/mc policy set public myminio/${S3_BUCKET_NAME};

--- a/justfile
+++ b/justfile
@@ -14,6 +14,9 @@ up service="":
 down:
 	{{ DC }} down
 
+logs service="":
+	{{ DC }} logs -f {{ service }}
+
 fresh-start:
 	# Tear down existing containers, remove volume
 	{{ DC }} down


### PR DESCRIPTION
## Description of Changes

This PR allows approved & confirmed volunteers to upload images directly to officers. Currently, volunteers can only classify images & assign classified images to cops. We have volunteers who are adept with the system and wish to upload photos that they or others they know have taken for officers that they already now. It's tedious for them to go through the classification/identification process. I've loosened the restrictions so that volunteers can do direct uploads.

There are also a few other small changes:
- New `just logs` command
- Tweaked some `minio` settings so everything operated smoothly and the console attached to a consistent port (rather than a dynamic one)

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
