### PR TITLE
Set minimum image size for officer faces

### DIFF
--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -568,3 +568,8 @@ tr:hover .row-actions {
 .bottom-10 {
     bottom: 10px;
 }
+
+.officer-face {
+    min-width: 200px;
+    min-height: 200px;
+}

--- a/OpenOversight/app/templates/image.html
+++ b/OpenOversight/app/templates/image.html
@@ -10,7 +10,7 @@
 
   <div class="row">
     <div class="col-sm-6">
-      <img src="{{ path }}" alt="Submission">
+      <img class="officer-face" src="{{ path }}" alt="Submission">
     </div>
     <div class="col-sm-6 col-md-4">
       <div class="thumbnail">

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -141,7 +141,7 @@
             <div class="row">
               <div class="col-md-6 col-xs-12">
                 <a href="{{ url_for('main.officer_profile', officer_id=officer.id) }}">
-                  <img src="{{ officer.image | default('/static/images/placeholder.png') }}" class="img-responsive thumbnail" alt="{{ officer.full_name() }}">
+                  <img class="officer-face" src="{{ officer.image | default('/static/images/placeholder.png') }}" class="img-responsive thumbnail" alt="{{ officer.full_name() }}">
                 </a>
               </div>
               <div class="col-md-6 col-xs-12">

--- a/OpenOversight/app/templates/partials/officer_faces.html
+++ b/OpenOversight/app/templates/partials/officer_faces.html
@@ -4,7 +4,7 @@
   <a href="{{ url_for('main.display_tag', tag_id=faces[loop.index - 1].id) }}">
 {% endif %}
 
-<img src="{{ path }}" alt="Submission">
+<img class="officer-face" src="{{ path }}" alt="Submission">
 
 {% if is_admin_or_coordinator %}
   </a>


### PR DESCRIPTION
## Description of Changes

This PR makes it so that officer images will be _at least_ 200px to a side. We have some images that are pretty small, this will help make sure users can still see them even if they're poor quality.

## Notes for Deployment

## Screenshots (if appropriate)

![Screenshot_2021-09-12_21-41-21](https://user-images.githubusercontent.com/10214785/133025066-58cbd7a7-f8e4-4a5a-bd90-559da4eca961.png)


## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
