### PR TITLE
Munger: 2021 salary data

### DIFF
--- a/OpenOversight/app/templates/partials/officer_salary.html
+++ b/OpenOversight/app/templates/partials/officer_salary.html
@@ -24,7 +24,7 @@
                         <td>(year incomplete)</td>
                         <td></td>
                     {% else %}
-                        <td></td>
+                        <td>$0</td>
                         <td>{{ '${:,.2f}'.format(total) }}</td>
                     {% endif %}
                 {% else %}

--- a/OpenOversight/app/templates/partials/officer_salary.html
+++ b/OpenOversight/app/templates/partials/officer_salary.html
@@ -19,15 +19,18 @@
                     {% if salary.overtime_pay > 0 %}
                         {% set total = total + salary.overtime_pay %}
                         <td>{{ '${:,.2f}'.format(salary.overtime_pay) }}</td>
+                        <td>{{ '${:,.2f}'.format(total) }}</td>
                     {% elif salary.overtime_pay < 0 %}
                         <td>(year incomplete)</td>
+                        <td></td>
                     {% else %}
                         <td></td>
+                        <td>{{ '${:,.2f}'.format(total) }}</td>
                     {% endif %}
                 {% else %}
                     <td></td>
+                    <td>{{ '${:,.2f}'.format(total) }}</td>
                 {% endif %}
-                <td>{{ '${:,.2f}'.format(total) }}</td>
 
                 <td>{% if salary.is_fiscal_year: %}FY {% endif %}{{ salary.year }}</td>
 

--- a/OpenOversight/app/templates/partials/officer_salary.html
+++ b/OpenOversight/app/templates/partials/officer_salary.html
@@ -14,17 +14,20 @@
         {% for salary in officer.salaries %}
             <tr>
                 <td>{{ '${:,.2f}'.format(salary.salary) }}</td>
+                {% set total = salary.salary %}
                 {% if salary.overtime_pay %}
                     {% if salary.overtime_pay > 0 %}
+                        {% set total = total + salary.overtime_pay %}
                         <td>{{ '${:,.2f}'.format(salary.overtime_pay) }}</td>
+                    {% elif salary.overtime_pay < 0 %}
+                        <td>(year incomplete)</td>
                     {% else %}
                         <td></td>
                     {% endif %}
-                    <td>{{ '${:,.2f}'.format(salary.salary + salary.overtime_pay) }}</td>
                 {% else %}
                     <td></td>
-                    <td></td>
                 {% endif %}
+                <td>{{ '${:,.2f}'.format(total) }}</td>
 
                 <td>{% if salary.is_fiscal_year: %}FY {% endif %}{{ salary.year }}</td>
 

--- a/data-munging/spd_2021_salary_data.py
+++ b/data-munging/spd_2021_salary_data.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+import logging
+from io import StringIO
+from pathlib import Path
+
+import click
+import pandas as pd
+import requests
+
+
+log = logging.getLogger()
+
+URL = "https://data.seattle.gov/api/views/2khk-5ukd/rows.csv?accessType=DOWNLOAD"
+
+
+def main(id_path: Path, output: Path):
+    log.info("Starting import")
+    response = requests.get(URL)
+    buffer = StringIO(response.text)
+    # Filter down to police department only, get only columns needed
+    df = pd.read_csv(buffer).query("Department == 'Police Department'")[
+        ["Last Name", "First Name", "Hourly Rate "]
+    ]
+    df.columns = ["last", "first", "hourly"]
+    ids = pd.read_csv(
+        id_path,
+        usecols=["id", "first name", "last name"],
+    )
+    ids.columns = ["id", "last", "first"]
+    # Remove Jr, IV, II, III, etc.
+    df.loc[:, "last"] = df["last"].replace(
+        r" ?((Jr)|(II)|(III)|(IV))\.?", "", regex=True
+    )
+    # Merge with prod data based on the first and last names
+    merged = df.merge(ids, how="left", on=["last", "first"]).astype(
+        {"id": pd.Int64Dtype()}
+    )
+    # Estimate yearly pay based on hourly rate
+    # ASSUMED: 40 hour work week, 50 weeks a year
+    merged["salary"] = merged["hourly"] * 40 * 50
+    # Split off the links that don't have an OpenOversight badge associated with them
+    _has_id = merged["id"].notna()
+    missing = merged[~_has_id]
+    missing_output = output.parent / f"{output.stem}__missing.csv"
+    log.info(f"Writing {len(missing)} missing records to {missing_output}")
+    missing.to_csv(missing_output, index=False)
+    merged = merged[_has_id]
+    # Reduce columns even more
+    merged = merged[["salary", "id"]]
+    # Rename columns for OO
+    merged.columns = ["salary", "officer_id"]
+    # Add an empty id column
+    merged["id"] = None
+    # Set the year to 2020
+    merged["year"] = 2021
+    # Convert the salary from "$###,###.##" to a float
+    merged.loc[:, "salary"] = (
+        merged["salary"].replace(r"[\$,]", "", regex=True).astype(float)
+    )
+    # Set overtime pay to -1 since the year is not over
+    merged["overtime_pay"] = -1
+    log.info(f"Writing {len(merged)} output records to {output}")
+    merged.to_csv(output, index=False)
+    log.info("Finished")
+
+
+@click.command()
+@click.argument("id_path", type=click.Path(exists=True, path_type=Path))
+@click.argument("output", type=click.Path(path_type=Path))
+def cli(id_path: Path, output: Path):
+    logging.basicConfig(
+        format="[%(asctime)s - %(name)s - %(lineno)3d][%(levelname)s] %(message)s",
+        level=logging.INFO,
+    )
+    main(id_path, output)
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Description of Changes
This PR adds a script for adding 2021 salary data to OO using the wage data that's available publicly for Seattle[^1]. It's based primarily on #50.

I also changed some of the logic with how pay data was shown on the frontend. Now, all records will show a "Total Pay" unless the "Overtime" is less than 0, which indicates that the year is incomplete.

[^1]: https://data.seattle.gov/City-Business/City-of-Seattle-Wage-Data/2khk-5ukd

## Notes for Deployment

2021 hourly rates are downloaded automatically from the above link.

The munging can be run with `python data-munging/spd_2021_salary_data.py <OO-CSV> <output>`.

The importer can then be run with `just import --salaries-csv /data/spd-2021-salary-data.csv "Seattle\ Police\ Department"`.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/10214785/138535974-23bdc285-12d2-4a5e-8868-ab5f592aa5a5.png)


## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
