### PR TITLE
Bugfix: Officer search result count

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 import sys
@@ -639,36 +640,33 @@ def list_officer(
     if not department:
         abort(404)
 
+    age_range = {ac[0] for ac in AGE_CHOICES}
+
     # Set form data based on URL
-    if request.args.get("min_age") and request.args.get("min_age") in [
-        ac[0] for ac in AGE_CHOICES
-    ]:
-        form_data["min_age"] = request.args.get("min_age")
-    if request.args.get("max_age") and request.args.get("max_age") in [
-        ac[0] for ac in AGE_CHOICES
-    ]:
-        form_data["max_age"] = request.args.get("max_age")
-    if request.args.get("page"):
-        page = int(request.args.get("page"))
-    if request.args.get("name"):
-        form_data["name"] = request.args.get("name")
-    if request.args.get("badge"):
-        form_data["badge"] = request.args.get("badge")
-    if request.args.get("unit") and request.args.get("unit") != "Not Sure":
-        form_data["unit"] = int(request.args.get("unit"))
-    if request.args.get("unique_internal_identifier"):
-        form_data["unique_internal_identifier"] = request.args.get(
-            "unique_internal_identifier"
-        )
-    if request.args.get("race") and all(
-        race in [rc[0] for rc in RACE_CHOICES] for race in request.args.getlist("race")
+    if (min_age_arg := request.args.get("min_age")) and min_age_arg in age_range:
+        form_data["min_age"] = min_age_arg
+    if (max_age_arg := request.args.get("max_age")) and max_age_arg in age_range:
+        form_data["max_age"] = max_age_arg
+    if page_arg := request.args.get("page"):
+        page = int(page_arg)
+    if name_arg := request.args.get("name"):
+        form_data["name"] = name_arg
+    if badge_arg := request.args.get("badge"):
+        form_data["badge"] = badge_arg
+    if (unit_arg := request.args.get("unit")) and unit_arg != "Not Sure":
+        form_data["unit"] = int(unit_arg)
+    if uid := request.args.get("unique_internal_identifier"):
+        form_data["unique_internal_identifier"] = uid
+    if (races := request.args.get("race")) and all(
+        race in [rc[0] for rc in RACE_CHOICES] for race in races
     ):
-        form_data["race"] = request.args.getlist("race")
-    if request.args.get("gender") and all(
+        form_data["race"] = races
+    if (genders := request.args.get("gender")) and all(
+        # Every time you complain we add a new gender
         gender in [gc[0] for gc in GENDER_CHOICES]
-        for gender in request.args.getlist("gender")
+        for gender in genders
     ):
-        form_data["gender"] = request.args.getlist("gender")
+        form_data["gender"] = genders
 
     unit_choices = [
         (unit.id, unit.descrip)
@@ -683,10 +681,10 @@ def list_officer(
         .order_by(Job.order)
         .all()
     ]
-    if request.args.get("rank") and all(
-        rank in rank_choices for rank in request.args.getlist("rank")
+    if (ranks := request.args.get("rank")) and all(
+        rank in rank_choices for rank in ranks
     ):
-        form_data["rank"] = request.args.getlist("rank")
+        form_data["rank"] = ranks
 
     officers = filter_by_form(form_data, Officer.query, department_id).filter(
         Officer.department_id == department_id
@@ -694,6 +692,7 @@ def list_officer(
     officers = officers.options(selectinload(Officer.face))
     officers = officers.order_by(Officer.last_name, Officer.first_name, Officer.id)
     officers = officers.paginate(page, OFFICERS_PER_PAGE, False)
+    logging.warning(f"======================================Officer count: {officers.total}")
     for officer in officers.items:
         officer_face = sorted(officer.face, key=lambda x: x.featured, reverse=True)
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import re
 import sys
@@ -657,11 +656,11 @@ def list_officer(
         form_data["unit"] = int(unit_arg)
     if uid := request.args.get("unique_internal_identifier"):
         form_data["unique_internal_identifier"] = uid
-    if (races := request.args.get("race")) and all(
+    if (races := request.args.getlist("race")) and all(
         race in [rc[0] for rc in RACE_CHOICES] for race in races
     ):
         form_data["race"] = races
-    if (genders := request.args.get("gender")) and all(
+    if (genders := request.args.getlist("gender")) and all(
         # Every time you complain we add a new gender
         gender in [gc[0] for gc in GENDER_CHOICES]
         for gender in genders
@@ -681,7 +680,7 @@ def list_officer(
         .order_by(Job.order)
         .all()
     ]
-    if (ranks := request.args.get("rank")) and all(
+    if (ranks := request.args.getlist("rank")) and all(
         rank in rank_choices for rank in ranks
     ):
         form_data["rank"] = ranks

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -691,8 +691,8 @@ def list_officer(
     )
     officers = officers.options(selectinload(Officer.face))
     officers = officers.order_by(Officer.last_name, Officer.first_name, Officer.id)
+    officers = officers.distinct(Officer.last_name, Officer.first_name, Officer.id)
     officers = officers.paginate(page, OFFICERS_PER_PAGE, False)
-    logging.warning(f"======================================Officer count: {officers.total}")
     for officer in officers.items:
         officer_face = sorted(officer.face, key=lambda x: x.featured, reverse=True)
 


### PR DESCRIPTION
## Description of Changes

Resolves #61

When a search was being made that included, in some way, a reference to `Assignments` (via job, unit, badge, etc), the `Assignments` table was joined to the `Officers` query. While this didn't affect the actual items that were shown on the page, it did affect the pagination count: since assignments were joined to officers, the individual officers had as many records as they had assignments that matched. E.g. a search on badge "5011" would return 1 officer but show 7 results, because we have 7 entries in the `Assignments` table for that officer with that badge.

This PR changes the logic so only distinct officers are returned in the query. This brings the pagination count in-line with the actual results displayed.

I also changed some of the arg retrieval logic so to use the walrus operator so things were a bit clearer.

## Notes for Deployment

(Results will still be inaccurate until #73 gets merged)

## Screenshots (if appropriate)

### Before
![image](https://user-images.githubusercontent.com/10214785/138778208-0b58f63d-2fb9-431e-b2fe-79c5cb42fb84.png)

### After
![image](https://user-images.githubusercontent.com/10214785/138778232-6a9ca00b-be0b-4aa8-83a1-6f5f15e9517f.png)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
