### PR TITLE
Bugfix: Main container bottom padding

### DIFF
--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -16,6 +16,10 @@ body {
   height: 100px;
 }
 
+div[role=main] {
+    padding-bottom: 30px;
+}
+
 .social:hover {
     color: #000000;
      -webkit-transform: scale(1.1);


### PR DESCRIPTION
## Description of Changes
Resolves #66

This PR adds a bit of padding to the bottom of main content container (`role="main"`) so that the sidebar button does not intersect with the footer.

## Notes for Deployment

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/10214785/138804272-a8f4e451-f26f-4edf-bbcb-ded8b596b73c.png)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
