### PR TITLE
Techbloc directory link in footer

### DIFF
--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -120,10 +120,18 @@
         <div class="col-sm-4">
           <h5>Contact</h5>
           <p>
-            <a href="http://twitter.com/TechBlocSEA" rel="noopener noreferrer" target="_blank"><i class="fa fa-twitter-square fa-3x social"></i></a>
-            <a href="https://github.com/SeattleDSA/OpenOversight" rel="noopener noreferrer" target="_blank"><i class="fa fa-github fa-3x social"></i></a>
-            <a href="mailto:techblocsea@protonmail.com"><i class="fa fa-envelope-square fa-3x social"></i></a>
-            <a href="https://tech-bloc-sea.dev/" rel="noopener noreferrer" target="_blank"><i class="fa fa-globe fa-3x social"></i></a>
+            <a title="TechBloc Twitter" href="http://twitter.com/TechBlocSEA" rel="noopener noreferrer" target="_blank">
+              <i class="fa fa-twitter-square fa-3x social" aria-hidden="true"></i>
+            </a>
+            <a title="OpenOversight GitHub" href="https://github.com/SeattleDSA/OpenOversight" rel="noopener noreferrer" target="_blank">
+              <i class="fa fa-github fa-3x social" aria-hidden="true"></i>
+            </a>
+            <a href="mailto:techblocsea@protonmail.com">
+              <i class="fa fa-envelope-square fa-3x social" aria-hidden="true"></i>
+            </a>
+            <a title="TechBloc Projects" href="https://tech-bloc-sea.dev/" rel="noopener noreferrer" target="_blank">
+              <i class="fa fa-globe fa-3x social" aria-hidden="true"></i>
+            </a>
             <br>
             <a href="/privacy" class="btn">Privacy Policy</a>
           </p>

--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -122,7 +122,9 @@
           <p>
             <a href="http://twitter.com/TechBlocSEA" rel="noopener noreferrer" target="_blank"><i class="fa fa-twitter-square fa-3x social"></i></a>
             <a href="https://github.com/SeattleDSA/OpenOversight" rel="noopener noreferrer" target="_blank"><i class="fa fa-github fa-3x social"></i></a>
-            <a href="mailto:techblocsea@protonmail.com"><i class="fa fa-envelope-square fa-3x social"></i></a><br>
+            <a href="mailto:techblocsea@protonmail.com"><i class="fa fa-envelope-square fa-3x social"></i></a>
+            <a href="https://tech-bloc-sea.dev/" rel="noopener noreferrer" target="_blank"><i class="fa fa-globe fa-3x social"></i></a>
+            <br>
             <a href="/privacy" class="btn">Privacy Policy</a>
           </p>
         </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ python-dateutil==2.8.1
 python-dotenv==0.7.1
 SQLAlchemy==1.4.21
 us==1.0
+WTForms<3.0.0


### PR DESCRIPTION
## Description of Changes
Resolves #33

This PR adds another favicon to the footer which links to our directory website. I just chose the globe since that seems to be the obvious "web" icon, but [here's the full list of icons](https://fontawesome.com/v4.7/icons/) - if there's a better one to pick let me know!

## Notes for Deployment

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/10214785/138805416-46c283c2-4963-4e3c-9f4a-dda7e79a6fcd.png)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
