### PR TITLE
Add backup just recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -51,3 +51,11 @@ import +args:
 # Run the static checks
 lint:
     pre-commit run --all-files
+
+# Back up the postgres data using loomchild/volume-backup
+backup location:
+    docker run --rm \
+        -v openoversight_postgres:/volume \
+        -v {{ location }}:/backup \
+        loomchild/volume-backup \
+        backup openoversight-postgres-$(date '+%Y-%m-%d').tar.bz2


### PR DESCRIPTION
## Description of Changes

This is a command I use frequently enough to backup the database that it warrants its own `just` recipe.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
