### PR TITLE
Make user profile view volunteer only

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -209,6 +209,7 @@ def get_tutorial():
 
 
 @main.route("/user/<username>")
+@login_required
 def profile(username):
     if re.search("^[A-Za-z][A-Za-z0-9_.]*$", username):
         user = User.query.filter_by(username=username).one()


### PR DESCRIPTION
## Description of Changes
This PR ensures that the user profile page is hidden behind user authentication. This ensures that a visitor must be a volunteer or admin in order to view user profile pages. While these pages are only accessible by knowing URLs (there are no links to the pages for anonymous users), this is a safety measure to ensure volunteers cannot be doxxed.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
