### PR TITLE
Reinstate tests, add to CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          # Force the use of the production requirements only
+          build-args: REQUIREMENTS_FILE=requirements.txt
           tags: |
             ghcr.io/${{ env.image_name }}:${{ github.sha }}
             ghcr.io/${{ env.image_name }}:${{ github.ref_name }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,3 +17,7 @@ jobs:
         run: pip install pre-commit
       - name: Run static checks
         run: just lint
+      - name: Run tests
+        run: |
+          just build
+          just test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,6 @@ jobs:
 
   static-checks:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - uses: extractions/setup-just@v1
@@ -17,6 +16,13 @@ jobs:
         run: pip install pre-commit
       - name: Run static checks
         run: just lint
+
+  tests:
+    runs-on: ubuntu-latest
+    needs: static-checks
+    steps:
+      - uses: actions/checkout@v2
+      - uses: extractions/setup-just@v1
       - name: Run tests
         run: |
           just build

--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -148,7 +148,7 @@ pip install -r requirements.txt
 and
 
 ```bash
-pip install -r dev-requirements.txt
+pip install -r requirements-dev.txt
 ```
 
 ## OpenOversight Management Interface

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.9-slim
 
 WORKDIR /usr/src/app
 
+ARG REQUIREMENTS_FILE=requirements-dev.txt
+
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV DEBIAN-FRONTEND noninteractive
 ENV PYTHONUNBUFFERED=1
@@ -28,8 +30,9 @@ RUN npm install -g yarn && \
 COPY yarn.lock /usr/src/app/
 RUN chmod -R 777 /usr/src/app/ /.cache /.yarn
 
-COPY requirements.txt /usr/src/app/
-RUN pip3 install -r requirements.txt
+# Always add the prod req because the dev reqs depend on it for deduplication
+COPY ${REQUIREMENTS_FILE} requirements.txt /usr/src/app/
+RUN pip3 install -r ${REQUIREMENTS_FILE}
 
 COPY package.json /usr/src/app/
 RUN yarn

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1174,7 +1174,7 @@ def download_incidents_csv(department_id):
         "time",
         "description",
         "location",
-        "licences",
+        "licenses",
         "links",
         "officers",
     ]

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -663,6 +663,7 @@ def client(app, request):
 @pytest.fixture
 def browser(app, request):
     # FIXME: Skip for now until I can get this working
+    # Possible solution: https://stackoverflow.com/questions/32151043/xvfb-docker-cannot-open-display
     pytest.skip("Xvfb not available in docker, it needs to be installed")
     # start server
     threading.Thread(target=app.run).start()

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -662,6 +662,8 @@ def client(app, request):
 
 @pytest.fixture
 def browser(app, request):
+    # FIXME: Skip for now until I can get this working
+    pytest.skip("Xvfb not available in docker, it needs to be installed")
     # start server
     threading.Thread(target=app.run).start()
     # give the server a few seconds to ensure it is up

--- a/OpenOversight/tests/test_commands.py
+++ b/OpenOversight/tests/test_commands.py
@@ -31,6 +31,12 @@ from OpenOversight.app.utils import get_officer
 from OpenOversight.tests.conftest import RANK_CHOICES_1, generate_officer
 
 
+@pytest.fixture(autouse=True)
+def input_yes(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda *_: "y")
+    yield
+
+
 def run_command_print_output(cli, args=None, **kwargs):
     """
     This function runs the given command with the provided arguments

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -13,6 +13,11 @@ from OpenOversight.tests.routes.route_helpers import login_user
 
 # Utils tests
 
+upload_s3_patch = patch(
+    "OpenOversight.app.utils.upload_obj_to_s3",
+    MagicMock(return_value="https://s3-some-bucket/someaddress.jpg"),
+)
+
 
 def test_department_filter(mockdata):
     department = OpenOversight.app.models.Department.query.first()
@@ -216,10 +221,7 @@ def test_unit_choices(mockdata):
     assert "Unit: Bureau of Organized Crime" in unit_choices
 
 
-@patch(
-    "OpenOversight.app.utils.upload_obj_to_s3",
-    MagicMock(return_value="https://s3-some-bucket/someaddress.jpg"),
-)
+@upload_s3_patch
 def test_upload_image_to_s3_and_store_in_db_increases_images_in_db(
     mockdata, test_png_BytesIO, client
 ):
@@ -229,23 +231,19 @@ def test_upload_image_to_s3_and_store_in_db_increases_images_in_db(
     assert Image.query.count() == original_image_count + 1
 
 
-@patch(
-    "OpenOversight.app.utils.upload_obj_to_s3",
-    MagicMock(return_value="https://s3-some-bucket/someaddress.jpg"),
-)
+@upload_s3_patch
 def test_upload_existing_image_to_s3_and_store_in_db_returns_existing_image(
     mockdata, test_png_BytesIO, client
 ):
+    # Disable file closing for this test
+    test_png_BytesIO.close = lambda: None
     firstUpload = upload_image_to_s3_and_store_in_db(test_png_BytesIO, 1, 1)
     secondUpload = upload_image_to_s3_and_store_in_db(test_png_BytesIO, 1, 1)
     assert type(secondUpload) == Image
     assert firstUpload.id == secondUpload.id
 
 
-@patch(
-    "OpenOversight.app.utils.upload_obj_to_s3",
-    MagicMock(return_value="https://s3-some-bucket/someaddress.jpg"),
-)
+@upload_s3_patch
 def test_upload_image_to_s3_and_store_in_db_does_not_set_tagged(
     mockdata, test_png_BytesIO, client
 ):

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,8 @@
 
 ## Tests and linting
 
- - [ ] I have rebased my changes on current `develop`
+ - [ ] I have rebased my changes on `main`
 
- - [ ] pytests pass in the development environment on my local machine
+ - [ ] `just lint` passes
 
- - [ ] `flake8` checks pass
+ - [ ] `just test` passes

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -41,6 +41,9 @@ services:
 
   web:
     build: .
+    depends_on:
+      - postgres
+      - minio
     environment:
       FLASK_ENV: development
       FLASK_DEBUG: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
 
   web:
     restart: always
+    depends_on:
+      - postgres
     image: ghcr.io/orcacollective/openoversight:${DB_IMAGE_TAG:-latest}
     env_file:
       - .env

--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ default:
 
 # Create the .env file from the template
 dotenv:
-    @([ ! -f .env ] && cp env.example .env) || true
+    @([ ! -f .env ] && cp .env.example .env) || true
 
 # Build all containers
 build: dotenv

--- a/justfile
+++ b/justfile
@@ -4,7 +4,8 @@ COMPOSE_FILE := "--file=docker-compose.yml" + (
     else {" --file=docker-compose.dev.yml"}
 )
 DC := "docker-compose " + COMPOSE_FILE
-RUN := DC + " run --rm web"
+RUN := DC + " run --rm"
+RUN_WEB := RUN + " web"
 set dotenv-load := false
 
 
@@ -44,12 +45,12 @@ fresh-start:
 	{{ DC }} build
 
 	# Start up and populate fields
-	{{ RUN }} python ../create_db.py
-	{{ RUN }} flask make-admin-user
-	{{ RUN }} flask add-department "Seattle Police Department" "SPD"
-	{{ RUN }} flask bulk-add-officers /data/init_data.csv
+	{{ RUN_WEB }} python ../create_db.py
+	{{ RUN_WEB }} flask make-admin-user
+	{{ RUN_WEB }} flask add-department "Seattle Police Department" "SPD"
+	{{ RUN_WEB }} flask bulk-add-officers /data/init_data.csv
 
-# Run a command using the web image
+# Run a command on a provided service
 run +args:
 	{{ RUN }} {{ args }}
 
@@ -59,11 +60,15 @@ db-shell:
 
 # Import a CSV file
 import +args:
-	{{ RUN }} flask advanced-csv-import {{ args }}
+	{{ RUN_WEB }} flask advanced-csv-import {{ args }}
 
 # Run the static checks
 lint:
     pre-commit run --all-files
+
+# Run tests in the web container
+test:
+    @just run --no-deps web pytest
 
 # Back up the postgres data using loomchild/volume-backup
 backup location:

--- a/justfile
+++ b/justfile
@@ -12,8 +12,12 @@ set dotenv-load := false
 default:
     @just -lu
 
+# Create the .env file from the template
+dotenv:
+    @([ ! -f .env ] && cp env.example .env) || true
+
 # Build all containers
-build:
+build: dotenv
 	{{ DC }} build
 
 # Spin up all (or the specified) services

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,8 @@
+-r requirements.txt
+
+ipython
 faker==0.7.3
-flake8==3.8.3  # if changing this, update .travis.yml too
+flake8==3.8.3
 mock==2.0.0
 mypy==0.782
 nose>=1.3.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,7 @@
 -r requirements.txt
-
-ipython
 faker==0.7.3
 flake8==3.8.3
+ipython
 mock==2.0.0
 mypy==0.782
 nose>=1.3.1


### PR DESCRIPTION
## Description of Changes
This PR resintates the tests!! There's only one set that's not working (the [xvfb](https://www.x.org/releases/X11R7.6/doc/man/man1/Xvfb.1.xhtml) based ones) and that's because they'll take a little extra work to get integrated. I also fixed some tests that were failing.

There are a ton of warnings from this. I've made #85 for one of them, there's nothing immediately pressing.

I've changed the Docker image so that we can specify which requirements file to install while building. For most cases this will install the dev requirements, which will also install the prod requirements. For when we're building the prod image, this will _only_ install the production requirements.

I also made some other changes:
- New `just test` recipe
- Added `just test` to PR checks
- Updated PR template

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
