### PR TITLE
Remove port config from base compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,6 @@ services:
     volumes:
       - ./data:/data/
     command: scripts/entrypoint.sh
-    ports:
-      - "3000:3000"
 
 volumes:
   postgres:


### PR DESCRIPTION
## Description of Changes
This PR removes the port mapping defined in the base docker-compose file. That port mapping differs in the prod file but Docker attempts to use the one present in the base as well. We already have the mapping in the dev file, so it doesn't need to be in the base one (and shouldn't, since it apparently can't be overridden). 

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
