### PR TITLE
Generalize data mungers, add roster update script

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,8 +13,6 @@ jobs:
         with:
           python-version: 3.9
       - uses: pre-commit/action@v2.0.3
-        env:
-          SKIP: isort  # Fixme: this isn't working on GHA, "setuptools" not found
         with:
           extra_args: --all-files
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: extractions/setup-just@v1
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install Dependencies
         run: pip install pre-commit
       - name: Run static checks

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,13 +9,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: extractions/setup-just@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Install Dependencies
-        run: pip install pre-commit
-      - name: Run static checks
-        run: just lint
+      - uses: pre-commit/action@v2.0.3
+        with:
+          extra_args: --all-files
 
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           python-version: 3.9
       - uses: pre-commit/action@v2.0.3
+        env:
+          SKIP: isort  # Fixme: this isn't working on GHA, "setuptools" not found
         with:
           extra_args: --all-files
 

--- a/data-munging/assignments.py
+++ b/data-munging/assignments.py
@@ -37,7 +37,7 @@ import pandas as pd
 from assignment_correction import title_corrections, unit_corrections
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 def find_termination(df: pd.DataFrame, roster_dates: List[str]) -> Optional[str]:
@@ -124,9 +124,9 @@ def extract_all_assignments(
     ids: pd.DataFrame, hist: pd.DataFrame
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """
-    Using the IDs provided and this historical records for all rosters, construct
-    a list of assignments & officers that may be missing from OpenOversight for officers
-    that were active *after* 2020-01-01.
+    Construct a list of assignments & officers that may be missing from OpenOversight
+    for officers that were active *after* 2020-01-01 by using the IDs provided and
+    the historical records for all rosters.
     Returns the assignments and missing officers as dfs ready to be written to CSV.
     """
     # Get a sorted list of all the unique roster dates
@@ -174,9 +174,11 @@ def extract_all_assignments(
     )
     merged = merged[merged["badge"].isin(recently_active_officers)]
     # Pull out officers not currently in OO
-    missing_officers = merged[merged["ooid"].str.startswith("#")].drop_duplicates(
-        subset=["badge"], keep="last"
-    ).reset_index(drop=True)
+    missing_officers = (
+        merged[merged["ooid"].str.startswith("#")]
+        .drop_duplicates(subset=["badge"], keep="last")
+        .reset_index(drop=True)
+    )
     log.info("Building output dataframes")
     # Reduce to minimum necessary and rename columns
     missing_officers = missing_officers[

--- a/data-munging/assignments.py
+++ b/data-munging/assignments.py
@@ -120,10 +120,15 @@ def apply_correction_mapping(
     return column.map(correct_mapping).fillna(column)
 
 
-def main(id_path: Path, historic_data_path: Path, output: Path):
-    log.info("Starting import")
-    ids = pd.read_csv(id_path, usecols=["id", "badge number"])
-    hist = pd.read_csv(historic_data_path)
+def extract_all_assignments(
+    ids: pd.DataFrame, hist: pd.DataFrame
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Using the IDs provided and this historical records for all rosters, construct
+    a list of assignments & officers that may be missing from OpenOversight for officers
+    that were active *after* 2020-01-01.
+    Returns the assignments and missing officers as dfs ready to be written to CSV.
+    """
     # Get a sorted list of all the unique roster dates
     roster_dates = sorted(hist["date"].unique())
     log.info("Correcting unit/title info")
@@ -155,7 +160,7 @@ def main(id_path: Path, historic_data_path: Path, output: Path):
     # provide this pseudo-badge as an internal reference for the importer. It will match
     # the records in the assignments CSV to any new officers that are created with the
     # same pseudo-badge.
-    merged["pseudo_badge"] = "#" + merged["badge"]
+    merged["pseudo_badge"] = "#" + merged["badge"].astype(str)
     # Convert the OOID column to a nullable interger, then to a string. If this isn't
     # done, then we get floating point numbers where we want ints.
     merged = merged.astype({"ooid": pd.Int64Dtype()}).astype({"ooid": str})
@@ -171,16 +176,14 @@ def main(id_path: Path, historic_data_path: Path, output: Path):
     # Pull out officers not currently in OO
     missing_officers = merged[merged["ooid"].str.startswith("#")].drop_duplicates(
         subset=["badge"], keep="last"
-    )
-    log.info("Writing output files")
+    ).reset_index(drop=True)
+    log.info("Building output dataframes")
     # Reduce to minimum necessary and rename columns
     missing_officers = missing_officers[
         ["last_name", "first_name", "middle_name", "ooid"]
     ].rename({"ooid": "id", "middle_name": "middle_initial"}, axis="columns")
     # Department name needed for ingestion
     missing_officers["department_name"] = "Seattle Police Department"
-    missing_path = output.parent / f"{output.stem}_missing_officers.csv"
-    missing_officers.to_csv(missing_path, index=False)
     # Pull out assignments
     # Reduce to minimum necessary and rename columns
     assignments = merged[
@@ -192,6 +195,18 @@ def main(id_path: Path, historic_data_path: Path, output: Path):
     )
     # Empty ID column needed for ingestion
     assignments["id"] = None
+    return assignments, missing_officers
+
+
+def main(id_path: Path, historic_data_path: Path, output: Path):
+    log.info("Starting import")
+    ids = pd.read_csv(id_path, usecols=["id", "badge number"])
+    hist = pd.read_csv(historic_data_path)
+    assignments, missing_officers = extract_all_assignments(ids, hist)
+    log.info("Writing output files")
+    # Reduce to minimum necessary and rename columns
+    missing_path = output.parent / f"{output.stem}_missing_officers.csv"
+    missing_officers.to_csv(missing_path, index=False)
     assignments.to_csv(output, index=False)
 
 

--- a/data-munging/common.py
+++ b/data-munging/common.py
@@ -1,0 +1,23 @@
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+
+log = logging.getLogger(__name__)
+
+
+def write_files_with_missing(
+    df: pd.DataFrame, missing: pd.DataFrame, output: Path
+) -> None:
+    """
+    Write out two dataframes: one for the original data and one for the records which
+    could not be matched to the missing data. The latter will be written to a file
+    with the name "<output>__missing.csv"
+    """
+    missing_output = output.parent / f"{output.stem}__missing.csv"
+    log.info(f"Writing {len(missing)} missing records to {missing_output}")
+    missing.to_csv(missing_output, index=False)
+    log.info(f"Writing {len(df)} output records to {output}")
+    df.to_csv(output, index=False)
+    log.info("Finished")

--- a/data-munging/demographic_data.py
+++ b/data-munging/demographic_data.py
@@ -1,20 +1,26 @@
 #!/usr/bin/env python
 import logging
+from io import StringIO
 from pathlib import Path
 
 import click
 import pandas as pd
+import requests
+
+import common
 
 
 log = logging.getLogger()
 
+URL = "https://data.seattle.gov/api/views/i2q9-thny/rows.csv?accessType=DOWNLOAD"
 
-def main(id_path: Path, demographic_path: Path, output: Path):
-    log.info("Starting import")
-    ids = pd.read_csv(id_path, usecols=["id", "badge number"])
+
+def match_demographics(ids: pd.DataFrame, url: str, convert_badge: bool = True):
+    response = requests.get(url)
+    buffer = StringIO(response.text)
     # Read only specific columns from the Crisis Data CSV
     demo = pd.read_csv(
-        demographic_path,
+        buffer,
         usecols=[
             "Officer ID",
             "Officer Gender",
@@ -50,7 +56,10 @@ def main(id_path: Path, demographic_path: Path, output: Path):
     # Merge with the ID spreadsheet based on badge
     merged = demo.merge(
         ids, how="left", left_on="badge", right_on="badge number"
-    ).astype({"id": pd.Int64Dtype()})
+    )
+    if convert_badge:
+        # Convert this to a nullable integer type if specified to ensure validity
+        merged = merged.astype({"id": pd.Int64Dtype()})
     # Split off the links that don't have an OpenOversight badge associated with them
     _has_id = merged["id"].notna()
     missing = merged[~_has_id]
@@ -63,24 +72,25 @@ def main(id_path: Path, demographic_path: Path, output: Path):
     merged = merged[_has_id]
     # Add the extra column info
     merged["department_name"] = "Seattle Police Department"
-    missing_output = output.parent / f"{output.stem}__missing.csv"
-    log.info(f"Writing {len(missing)} missing records to {missing_output}")
-    missing.to_csv(missing_output, index=False)
-    log.info(f"Writing {len(merged)} output records to {output}")
-    merged.to_csv(output, index=False)
-    log.info("Finished")
+    return merged, missing
+
+
+def main(id_path: Path, output: Path):
+    log.info("Starting import")
+    ids = pd.read_csv(id_path, usecols=["id", "badge number"])
+    merged, missing = match_demographics(ids, URL)
+    common.write_files_with_missing(merged, missing, output)
 
 
 @click.command()
 @click.argument("id_path", type=click.Path(exists=True, path_type=Path))
-@click.argument("demographic_path", type=click.Path(exists=True, path_type=Path))
 @click.argument("output", type=click.Path(path_type=Path))
-def cli(id_path: Path, demographic_path: Path, output: Path):
+def cli(id_path: Path, output: Path):
     logging.basicConfig(
         format="[%(asctime)s - %(name)s - %(lineno)3d][%(levelname)s] %(message)s",
         level=logging.INFO,
     )
-    main(id_path, demographic_path, output)
+    main(id_path, output)
 
 
 if __name__ == "__main__":

--- a/data-munging/demographic_data.py
+++ b/data-munging/demographic_data.py
@@ -4,13 +4,12 @@ from io import StringIO
 from pathlib import Path
 
 import click
+import common
 import pandas as pd
 import requests
 
-import common
 
-
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 URL = "https://data.seattle.gov/api/views/i2q9-thny/rows.csv?accessType=DOWNLOAD"
 
@@ -54,9 +53,7 @@ def match_demographics(ids: pd.DataFrame, url: str, convert_badge: bool = True):
     # Badge has spaces after it in the Crisis Data CSV, so drop that
     demo.loc[:, "badge"] = demo["badge"].str.strip()
     # Merge with the ID spreadsheet based on badge
-    merged = demo.merge(
-        ids, how="left", left_on="badge", right_on="badge number"
-    )
+    merged = demo.merge(ids, how="left", left_on="badge", right_on="badge number")
     if convert_badge:
         # Convert this to a nullable integer type if specified to ensure validity
         merged = merged.astype({"id": pd.Int64Dtype()})

--- a/data-munging/divest_spd_links.py
+++ b/data-munging/divest_spd_links.py
@@ -6,7 +6,7 @@ import click
 import pandas as pd
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 def main(id_path: Path, link_path: Path, output: Path):

--- a/data-munging/first_employed_date.py
+++ b/data-munging/first_employed_date.py
@@ -14,23 +14,25 @@ import pandas as pd
 log = logging.getLogger()
 
 
-def get_first_employed(assignments: pd.DataFrame) -> pd.DataFrame:
+def get_first_employed(
+    assignments: pd.DataFrame, space_in_name: bool = True
+) -> pd.DataFrame:
+    officer_id = "officer id" if space_in_name else "officer_id"
+    start_date = "start date" if space_in_name else "start_date"
     # Sort input CSV first by officer, then by start date (ascending).
     # Group by officer, and grab the first row. This will have their first assignment
     # date on record.
     first_employed = (
-        assignments.sort_values(by=["officer id", "start date"])
-        .groupby("officer id")
-        .first()
+        assignments.sort_values(by=[officer_id, start_date]).groupby(officer_id).first()
     )
     # The index is now officer id, so we only need to keep the start date column.
     # (double brackets here so the entity remains a dataframe and not a series)
-    first_employed = first_employed[["start date"]]
+    first_employed = first_employed[[start_date]]
     # Add the department name
     first_employed["department_name"] = "Seattle Police Department"
     # Rename to the fields OO is expecting
     first_employed = first_employed.reset_index().rename(
-        {"officer id": "id", "start date": "employment_date"}, axis="columns"
+        {officer_id: "id", start_date: "employment_date"}, axis="columns"
     )
     return first_employed
 

--- a/data-munging/first_employed_date.py
+++ b/data-munging/first_employed_date.py
@@ -14,9 +14,7 @@ import pandas as pd
 log = logging.getLogger()
 
 
-def main(assignment_path: Path, output: Path):
-    log.info("Starting import")
-    assignments = pd.read_csv(assignment_path)
+def get_first_employed(assignments: pd.DataFrame) -> pd.DataFrame:
     # Sort input CSV first by officer, then by start date (ascending).
     # Group by officer, and grab the first row. This will have their first assignment
     # date on record.
@@ -34,6 +32,13 @@ def main(assignment_path: Path, output: Path):
     first_employed = first_employed.reset_index().rename(
         {"officer id": "id", "start date": "employment_date"}, axis="columns"
     )
+    return first_employed
+
+
+def main(assignment_path: Path, output: Path):
+    log.info("Starting import")
+    assignments = pd.read_csv(assignment_path)
+    first_employed = get_first_employed(assignments)
     # Save!
     first_employed.to_csv(output, index=False)
     log.info("Finished")

--- a/data-munging/first_employed_date.py
+++ b/data-munging/first_employed_date.py
@@ -11,7 +11,7 @@ import click
 import pandas as pd
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 def get_first_employed(

--- a/data-munging/integrate_latest_roster.py
+++ b/data-munging/integrate_latest_roster.py
@@ -25,13 +25,12 @@ import logging
 from pathlib import Path
 from typing import NamedTuple
 
-import click
-import pandas as pd
-
 import assignments as assignments_module
-import first_employed_date as first_employed_date_module
-import spd_2021_salary_data as spd_2021_salary_data_module
+import click
 import demographic_data as demographic_module
+import first_employed_date as first_employed_date_module
+import pandas as pd
+import spd_2021_salary_data as spd_2021_salary_data_module
 
 
 log = logging.getLogger(__name__)

--- a/data-munging/integrate_latest_roster.py
+++ b/data-munging/integrate_latest_roster.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+"""
+FIXME
+Assignment Creation Script.
+
+This script takes the historic SPD data and converts it into two new CSVs: a list of
+officers currently missing from OpenOversight, and a list of assignments for all
+officers. The missing officers are all officers who were not part of the 2021-06-30
+roster and were on the force prior to 2020.
+
+The original upload included some assignment/job information. *That data will need to be
+deleted before this insertion can run!!*. The following is the SQL needed to accomplish
+this:
+
+DELETE FROM assignments WHERE department_id = 1;
+DELETE FROM jobs WHERE department_id = 1;
+
+Alternatively, if there are no other departments to worry about:
+TRUNCATE jobs, assignments RESTART IDENTITY;
+
+Additionally, the now-defunct units can be removed with the following command:
+DELETE FROM unit_types WHERE id IN (
+    SELECT u.id
+    FROM unit_types u
+    LEFT JOIN assignments a
+        ON u.id = a.unit_id
+        WHERE a.id IS NULL
+);
+"""
+import logging
+from functools import partial
+from pathlib import Path
+from typing import NamedTuple
+
+import click
+import pandas as pd
+
+import assignments as assignments_module
+import first_employed_date as first_employed_date_module
+import spd_2021_salary_data as spd_2021_salary_data_module
+import demographic_data as demographic_module
+
+
+log = logging.getLogger(__name__)
+
+
+class DataFiles(NamedTuple):
+    oo_officers: Path
+    historical_roster: Path
+    spd_2021_salary: str = (
+        "https://data.seattle.gov/api/views/2khk-5ukd/rows.csv?accessType=DOWNLOAD"
+    )
+    demographic_data: str = (
+        "https://data.seattle.gov/api/views/i2q9-thny/rows.csv?accessType=DOWNLOAD"
+    )
+
+
+def _data_path(csv_name: str) -> click.command:
+    return click.argument(csv_name, type=click.Path(exists=True, path_type=Path))
+
+
+def _output_data(df: pd.DataFrame, output: Path, name: str) -> None:
+    path = output.parent / f"{output.stem}__{name}.csv"
+    log.info(f"Writing {name} data to {path}")
+    df.to_csv(path, index=False)
+
+
+def main(files: DataFiles, output: Path):
+    log.info("Starting import")
+    officers = pd.read_csv(files.oo_officers)
+    hist = pd.read_csv(files.historical_roster, low_memory=False)
+    # Compute assignments and any new officers
+    log.info("Computing assignments and new officers")
+    assignments, new_officers = assignments_module.extract_all_assignments(
+        officers[["id", "badge number"]].copy(), hist
+    )
+    log.info("Computing first employed date")
+    # For new officers, compute the first employed date
+    first_employed_date = first_employed_date_module.get_first_employed(
+        assignments.copy(), space_in_name=False
+    )
+    new_officers = new_officers.merge(
+        first_employed_date, on=["id", "department_name"], how="left"
+    )
+    ids_for_salary = new_officers[["id", "last_name", "first_name"]].copy()
+    log.info("Computing 2021 salary")
+    salary_2021, _ = spd_2021_salary_data_module.match_salary_data(
+        ids=ids_for_salary,
+        url=files.spd_2021_salary,
+        convert_id=False,
+    )
+    # The new officers don't include badge numbers (those are populated by
+    # assignments), so we need to temporarily add it here
+    log.info("Computing demographics")
+    demo_match = new_officers.copy()
+    demo_match["badge number"] = new_officers["id"].str.strip("#")
+    demographics, _ = demographic_module.match_demographics(
+        ids=demo_match,
+        url=files.demographic_data,
+        convert_badge=False,
+    )
+    new_officers = new_officers.merge(
+        demographics, on=["id", "department_name"], how="left"
+    )
+    log.info("Writing output files")
+    _output_data(new_officers, output, "officers")
+    _output_data(assignments, output, "assignments")
+    _output_data(salary_2021, output, "salary_2021")
+
+
+@click.command()
+@_data_path("oo_officers")
+@_data_path("historical_roster")
+@click.argument("output", type=click.Path(path_type=Path))
+def cli(
+    oo_officers: Path,
+    historical_roster: Path,
+    output: Path,
+):
+    logging.basicConfig(
+        format="[%(asctime)s - %(name)s - %(lineno)3d][%(levelname)s] %(message)s",
+        level=logging.INFO,
+    )
+    files = DataFiles(
+        oo_officers=oo_officers,
+        historical_roster=historical_roster,
+    )
+    main(files, output)
+
+
+if __name__ == "__main__":
+    cli()

--- a/data-munging/spd_2020_salary_data.py
+++ b/data-munging/spd_2020_salary_data.py
@@ -3,13 +3,12 @@ import logging
 from pathlib import Path
 
 import click
+import common
 import numpy as np
 import pandas as pd
 
-import common
 
-
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 def match_salary_data(

--- a/data-munging/spd_2020_salary_data.py
+++ b/data-munging/spd_2020_salary_data.py
@@ -6,17 +6,19 @@ import click
 import numpy as np
 import pandas as pd
 
+import common
+
 
 log = logging.getLogger()
 
 
-def main(id_path: Path, data: Path, output: Path):
-    log.info("Starting import")
-    df = pd.read_csv(data, usecols=["Name", "Base Pay", "Overtime"])
-    ids = pd.read_csv(
-        id_path,
-        usecols=["id", "first name", "last name"],
-    )
+def match_salary_data(
+    ids: pd.DataFrame, df: pd.DataFrame
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Match salary data based on name from the provided data.
+    Returns the salary dataframe as well as officers that were not matched.
+    """
     ids.columns = ["id", "last", "first"]
     # Remove Jr, IV, II, III, etc.
     df.loc[:, "Name"] = df.Name.replace(r" ?((Jr)|(II)|(III)|(IV))\.?", "", regex=True)
@@ -34,9 +36,6 @@ def main(id_path: Path, data: Path, output: Path):
     # Split off the links that don't have an OpenOversight badge associated with them
     _has_id = merged["id"].notna()
     missing = merged[~_has_id]
-    missing_output = output.parent / f"{output.stem}__missing.csv"
-    log.info(f"Writing {len(missing)} missing records to {missing_output}")
-    missing.to_csv(missing_output, index=False)
     merged = merged[_has_id]
     # Reduce columns even more
     merged = merged[["Base Pay", "Overtime", "id"]]
@@ -60,9 +59,18 @@ def main(id_path: Path, data: Path, output: Path):
         .replace("", np.nan)
         .astype(float)
     )
-    log.info(f"Writing {len(merged)} output records to {output}")
-    merged.to_csv(output, index=False)
-    log.info("Finished")
+    return merged, missing
+
+
+def main(id_path: Path, data: Path, output: Path):
+    log.info("Starting import")
+    df = pd.read_csv(data, usecols=["Name", "Base Pay", "Overtime"])
+    ids = pd.read_csv(
+        id_path,
+        usecols=["id", "first name", "last name"],
+    )
+    merged, missing = match_salary_data(ids, df)
+    common.write_files_with_missing(merged, missing, output)
 
 
 @click.command()

--- a/data-munging/spd_2021_salary_data.py
+++ b/data-munging/spd_2021_salary_data.py
@@ -4,13 +4,12 @@ from io import StringIO
 from pathlib import Path
 
 import click
+import common
 import pandas as pd
 import requests
 
-import common
 
-
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 URL = "https://data.seattle.gov/api/views/2khk-5ukd/rows.csv?accessType=DOWNLOAD"
 


### PR DESCRIPTION
## Description of Changes
This PR generalizes the individual data mungers into reusable modules, and then uses those modules to create a script which will add new officers and compute assignment information for all users. This will be incredibly helpful for continuing to update the data while SPD's roster changes (with hires/departures).

## Notes for Deployment

The following steps should be made in order to deploy this:
1. Download the officer CSV from production
1. Download the historic roster from `spd-lookup` (I just `git pull` and use the copy locally)
1. Use the CSV to generate the **three** CSVs to be uploaded (this also needs to be run from the `data-munging` directory): `./integrate_latest_roster.py [OO-OFFICER-CSV] [HISTORICAL-CSV] [OUTPUT-CSV]`
1. **[IMPORTANT]** Back up the database
1. **[IMPORTANT]** Truncate the assignments & jobs tables
1. Upload the files to the prod server
1. Use `just` to load the data: `just import --officers-csv /data/spd_2021-12-28_update__officers.csv --assignments-csv /data/spd_2021-12-28_update__assignments.csv --salaries-csv /data/spd_2021-12-28_update__salary_2021.csv "Seattle\ Police\ Department"`

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/10214785/147613940-f5e7f879-7275-4789-817e-8728e1c700e0.png)


## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
