### PR TITLE
Allow "Not Sure" rank in search flow

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -767,7 +767,7 @@ def get_dept_ranks(department_id=None, is_sworn_officer=None):
         ranks = Job.query.all()  # Not filtering by is_sworn_officer
         # Prevent duplicate ranks
         rank_list = sorted(
-            set([(rank.id, rank.job_title) for rank in ranks]),
+            set((rank.id, rank.job_title) for rank in ranks),
             key=lambda x: x[1],
         )
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -761,13 +761,15 @@ def get_dept_ranks(department_id=None, is_sworn_officer=None):
         ranks = Job.query.filter_by(department_id=department_id)
         if is_sworn_officer:
             ranks = ranks.filter_by(is_sworn_officer=True)
-        ranks = ranks.order_by(Job.order.asc()).all()
+        ranks = ranks.order_by(Job.job_title).all()
         rank_list = [(rank.id, rank.job_title) for rank in ranks]
     else:
         ranks = Job.query.all()  # Not filtering by is_sworn_officer
-        rank_list = list(
-            set([(rank.id, rank.job_title) for rank in ranks])
-        )  # Prevent duplicate ranks
+        # Prevent duplicate ranks
+        rank_list = sorted(
+            set([(rank.id, rank.job_title) for rank in ranks]),
+            key=lambda x: x[1],
+        )
 
     return jsonify(rank_list)
 

--- a/OpenOversight/app/static/js/find_officer.js
+++ b/OpenOversight/app/static/js/find_officer.js
@@ -40,7 +40,7 @@ $(document).ready(function() {
             const rank_box = $('select#rank')
             // Add the null case first
             rank_box.append(
-                $('<option></option>').attr("value", "Not Sure").text("Not Sure")
+                $('<option value="Not Sure">Not Sure</option>')
             );
             for (i = 0; i < ranks.length; i++) {
                 console.log(ranks[i]);

--- a/OpenOversight/app/static/js/find_officer.js
+++ b/OpenOversight/app/static/js/find_officer.js
@@ -43,7 +43,6 @@ $(document).ready(function() {
                 $('<option value="Not Sure">Not Sure</option>')
             );
             for (i = 0; i < ranks.length; i++) {
-                console.log(ranks[i]);
                 rank_box.append(
                     $('<option></option>').attr("value", ranks[i][1]).text(ranks[i][1])
                 );

--- a/OpenOversight/app/static/js/find_officer.js
+++ b/OpenOversight/app/static/js/find_officer.js
@@ -37,7 +37,7 @@ $(document).ready(function() {
             data: {department_id: dept_id}
         }).done(function(ranks) {
             $('input#rank').replaceWith('<select class="form-control" id="rank" name="rank">');
-            var rank_box = $('select#rank')
+            const rank_box = $('select#rank')
             // Add the null case first
             rank_box.append(
                 $('<option></option>').attr("value", "Not Sure").text("Not Sure")

--- a/OpenOversight/app/static/js/find_officer.js
+++ b/OpenOversight/app/static/js/find_officer.js
@@ -37,9 +37,14 @@ $(document).ready(function() {
             data: {department_id: dept_id}
         }).done(function(ranks) {
             $('input#rank').replaceWith('<select class="form-control" id="rank" name="rank">');
+            var rank_box = $('select#rank')
+            // Add the null case first
+            rank_box.append(
+                $('<option></option>').attr("value", "Not Sure").text("Not Sure")
+            );
             for (i = 0; i < ranks.length; i++) {
                 console.log(ranks[i]);
-                $('select#rank').append(
+                rank_box.append(
                     $('<option></option>').attr("value", ranks[i][1]).text(ranks[i][1])
                 );
             }


### PR DESCRIPTION
## Description of Changes

This PR allows users to select "Not Sure" for an officers rank when searching for one. Previously users would have to select a specific rank, which is not useful because we have over 100! I think ideally we'd have this be a multiple-select form, but that's for a separate PR.

I've also made it so that the ranks are sorted by name, rather than "order". I have no idea what that's useful for so I've changed it.

## Notes for Deployment

## Screenshots (if appropriate)

### Before
![Screenshot_2021-12-28_19-29-28](https://user-images.githubusercontent.com/10214785/147624829-48692c49-548a-4692-a096-9b7d2f8dfa21.png)

### After
![Screenshot_2021-12-28_19-30-01](https://user-images.githubusercontent.com/10214785/147624835-2d610d76-dbb4-47d7-99a9-b8d202f330a9.png)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
