### PR TITLE
Improve unit & rank search filters

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -107,13 +107,6 @@ def create_app(config_name="default"):
         """
         return " in " if form_data.get(field) else ""
 
-    @app.template_filter("currently_on_force")
-    def officer_currently_on_force(assignments):
-        if not assignments:
-            return "Uncertain"
-        most_recent = max(assignments, key=lambda x: x.star_date or datetime.date.min)
-        return "Yes" if most_recent.resign_date is None else "No"
-
     # Add commands
     Migrate(
         app, db, os.path.join(os.path.dirname(__file__), "..", "migrations")

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -563,6 +563,12 @@ class BrowseForm(Form):
         get_label="job_title",
         get_pk=lambda job: job.job_title,
     )  # query set in view function
+    unit = QuerySelectField(
+        "unit",
+        validators=[Optional()],
+        get_label="descrip",
+        get_pk=lambda unit: unit.descrip,
+    )  # query set in view function
     name = StringField("Last name")
     badge = StringField("Badge number")
     unique_internal_identifier = StringField("Unique ID")

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -637,7 +637,7 @@ def list_officer(
     form_data["max_age"] = max_age
     form_data["name"] = name
     form_data["badge"] = badge
-    form_data["unit"] = unit
+    form_data["unit"] = unit or []
     form_data["unique_internal_identifier"] = unique_internal_identifier
 
     OFFICERS_PER_PAGE = int(current_app.config["OFFICERS_PER_PAGE"])
@@ -658,8 +658,6 @@ def list_officer(
         form_data["name"] = name_arg
     if badge_arg := request.args.get("badge"):
         form_data["badge"] = badge_arg
-    if (unit_arg := request.args.get("unit")) and unit_arg != "Not Sure":
-        form_data["unit"] = int(unit_arg)
     if uid := request.args.get("unique_internal_identifier"):
         form_data["unique_internal_identifier"] = uid
     if (races := request.args.getlist("race")) and all(
@@ -674,8 +672,9 @@ def list_officer(
         form_data["gender"] = genders
 
     unit_choices = [
-        (unit.id, unit.descrip)
-        for unit in Unit.query.filter_by(department_id=department_id)
+        uc[0]
+        for uc in db.session.query(Unit.descrip)
+        .filter_by(department_id=department_id)
         .order_by(Unit.descrip.asc())
         .all()
     ]
@@ -683,9 +682,13 @@ def list_officer(
         jc[0]
         for jc in db.session.query(Job.job_title, Job.order)
         .filter_by(department_id=department_id)
-        .order_by(Job.order)
+        .order_by(Job.job_title)
         .all()
     ]
+    if (units := request.args.getlist("unit")) and all(
+        unit in unit_choices for unit in units
+    ):
+        form_data["unit"] = units
     if (ranks := request.args.getlist("rank")) and all(
         rank in rank_choices for rank in ranks
     ):
@@ -710,7 +713,7 @@ def list_officer(
         "race": RACE_CHOICES,
         "gender": GENDER_CHOICES,
         "rank": [(rc, rc) for rc in rank_choices],
-        "unit": [("Not Sure", "Not Sure")] + unit_choices,
+        "unit": [("Not Sure", "Not Sure")] + [(uc, uc) for uc in unit_choices],
     }
 
     next_url = url_for(

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -613,9 +613,9 @@ def edit_department(department_id):
 def list_officer(
     department_id,
     page=1,
-    race=[],
-    gender=[],
-    rank=[],
+    race=None,
+    gender=None,
+    rank=None,
     min_age="16",
     max_age="100",
     name=None,
@@ -630,9 +630,9 @@ def list_officer(
         .all()
     )
     form_data = form.data
-    form_data["race"] = race
-    form_data["gender"] = gender
-    form_data["rank"] = rank
+    form_data["race"] = race or []
+    form_data["gender"] = gender or []
+    form_data["rank"] = rank or []
     form_data["min_age"] = min_age
     form_data["max_age"] = max_age
     form_data["name"] = name

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -188,6 +188,12 @@ class Officer(BaseModel):
                 self.assignments_lazy, key=lambda x: x.star_date or date.min
             ).job.job_title
 
+    def unit_descrip(self):
+        if self.assignments_lazy:
+            return max(
+                self.assignments_lazy, key=lambda x: x.star_date or date.min
+            ).unit.descrip
+
     def badge_number(self):
         if self.assignments_lazy:
             return max(

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -190,9 +190,10 @@ class Officer(BaseModel):
 
     def unit_descrip(self):
         if self.assignments_lazy:
-            return max(
+            unit = max(
                 self.assignments_lazy, key=lambda x: x.star_date or date.min
-            ).unit.descrip
+            ).unit
+            return unit.descrip if unit else None
 
     def badge_number(self):
         if self.assignments_lazy:

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -206,6 +206,7 @@ class Officer(BaseModel):
                 self.assignments_lazy, key=lambda x: x.star_date or date.min
             )
             return "Yes" if most_recent.resign_date is None else "No"
+        return "Uncertain"
 
     def __repr__(self):
         if self.unique_internal_identifier:

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -200,6 +200,13 @@ class Officer(BaseModel):
                 self.assignments_lazy, key=lambda x: x.star_date or date.min
             ).star_no
 
+    def currently_on_force(self):
+        if self.assignments_lazy:
+            most_recent = max(
+                self.assignments_lazy, key=lambda x: x.star_date or date.min
+            )
+            return "Yes" if most_recent.resign_date is None else "No"
+
     def __repr__(self):
         if self.unique_internal_identifier:
             return "<Officer ID {}: {} {} {} {} ({})>".format(

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -484,6 +484,11 @@ tr:hover .row-actions {
     padding: 5px 0;
 }
 
+.filter-sidebar .panel-body-long {
+    height: 20vh;
+    overflow-y: scroll;
+}
+
 .filter-sidebar .panel-heading .accordion-toggle:after {
     font-family: 'Glyphicons Halflings';
     content: "\e252";

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -485,8 +485,8 @@ tr:hover .row-actions {
 }
 
 .filter-sidebar .panel-body-long {
-    height: 20vh;
-    overflow-y: scroll;
+    max-height: 20vh;
+    overflow-y: auto;
 }
 
 .filter-sidebar .panel-heading .accordion-toggle:after {

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -70,7 +70,7 @@
             <h3 class="panel-title accordion-toggle">Rank</h3>
           </div>
           <div class="collapse {{ form_data | field_in_query("rank") }}" id="filter-rank">
-            <div class="panel-body">
+            <div class="panel-body panel-body-long">
               <div class="form-group checkbox">
                 {% for choice in choices['rank'] %}
                   <label class="form-check">
@@ -86,7 +86,7 @@
             <h3 class="panel-title accordion-toggle">Unit</h3>
           </div>
           <div class="collapse {{ form_data | field_in_query("unit") }}" id="filter-unit">
-            <div class="panel-body">
+            <div class="panel-body panel-body-long">
               <div class="form-group">
                 <div class="form-group checkbox">
                     {% for choice in choices['unit'] %}

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -154,14 +154,16 @@
                 <div class="row">
                   <div class="col-md-6 col-xs-6">
                     <dl>
-                      <dt>Job Title</dt>
+                      <dt>Rank</dt>
                       <dd>{{ officer.job_title()|default('Unknown') }}</dd>
-                      <dt>Race</dt>
-                      <dd>{{ officer.race_label()|default('Unknown')|lower|title }}</dd>
+                      <dt>Unit</dt>
+                      <dd>{{ officer.unit_descrip()|default('Unknown') }}</dd>
                     </dl>
                   </div>
                   <div class="col-md-6 col-xs-6">
                     <dl>
+                      <dt>Race</dt>
+                      <dd>{{ officer.race_label()|default('Unknown')|lower|title }}</dd>
                       <dt>Gender</dt>
                       <dd>{{ officer.gender_label()|default('Unknown') }}</dd>
                       <dt>Number of Photos</dt>

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -88,11 +88,13 @@
           <div class="collapse {{ form_data | field_in_query("unit") }}" id="filter-unit">
             <div class="panel-body">
               <div class="form-group">
-                <select class="form-control" name="unit">
-                  {% for choice in choices['unit'] %}
-                  <option id="unit-{{ choice[0] }}" value="{{choice[0]}}" {% if choice[0] == form_data['unit'] %}selected='true'{% endif %}>{{choice[1]}}</option>
-                  {% endfor %}
-                </select>
+                <div class="form-group checkbox">
+                    {% for choice in choices['unit'] %}
+                        <label class="form-check">
+                            <input type="checkbox" class="form-check-input" id="unit-{{ choice[0] }}" name="unit" value="{{ choice[0] }}" {% if choice[0] in form_data['unit'] %}checked="checked" {% endif %}/>{{choice[1]}}
+                        </label>
+                    {% endfor %}
+                </div>
               </div>
             </div>
           </div>

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -158,6 +158,8 @@
                       <dd>{{ officer.job_title()|default('Unknown') }}</dd>
                       <dt>Unit</dt>
                       <dd>{{ officer.unit_descrip()|default('Unknown') }}</dd>
+                      <dt>Currently on the Force</dt>
+                      <dd>{{ officer.currently_on_force()|default('Uncertain') }}</dd>
                     </dl>
                   </div>
                   <div class="col-md-6 col-xs-6">

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -159,7 +159,7 @@
                       <dt>Unit</dt>
                       <dd>{{ officer.unit_descrip()|default('Unknown') }}</dd>
                       <dt>Currently on the Force</dt>
-                      <dd>{{ officer.currently_on_force()|default('Uncertain') }}</dd>
+                      <dd>{{ officer.currently_on_force() }}</dd>
                     </dl>
                   </div>
                   <div class="col-md-6 col-xs-6">

--- a/OpenOversight/app/templates/partials/officer_general_information.html
+++ b/OpenOversight/app/templates/partials/officer_general_information.html
@@ -50,7 +50,7 @@
                 </tr>
                 <tr>
                     <td><b>Currently on the force</b></td>
-                    <td>{{ assignments | currently_on_force }}</td>
+                    <td>{{ officer.currently_on_force() | default("Uncertain") }}</td>
                 </tr>
             </tbody>
         </table>

--- a/OpenOversight/app/templates/partials/officer_general_information.html
+++ b/OpenOversight/app/templates/partials/officer_general_information.html
@@ -50,7 +50,7 @@
                 </tr>
                 <tr>
                     <td><b>Currently on the force</b></td>
-                    <td>{{ officer.currently_on_force() | default("Uncertain") }}</td>
+                    <td>{{ officer.currently_on_force() }}</td>
                 </tr>
             </tbody>
         </table>

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -348,20 +348,29 @@ def filter_by_form(form_data, officer_query, department_id=None):
             .all()
         ]
 
-        print(form_data)
         if "Not Sure" in form_data["rank"]:
             form_data["rank"].append(None)
 
-    if form_data.get("badge") or form_data.get("unit") or job_ids:
+    unit_ids = []
+    if form_data.get("unit"):
+        unit_ids = [
+            unit.id
+            for unit in Unit.query.filter_by(department_id=department_id)
+            .filter(Unit.descrip.in_(form_data.get("unit")))
+            .all()
+        ]
+
+        if "Not Sure" in form_data["unit"]:
+            form_data["unit"].append(None)
+
+    if form_data.get("badge") or unit_ids or job_ids:
         officer_query = officer_query.join(Officer.assignments)
         if form_data.get("badge"):
             officer_query = officer_query.filter(
                 Assignment.star_no.like("%%{}%%".format(form_data["badge"]))
             )
-        if form_data.get("unit"):
-            officer_query = officer_query.filter(
-                Assignment.unit_id == form_data["unit"]
-            )
+        if unit_ids:
+            officer_query = officer_query.filter(Assignment.unit_id.in_(unit_ids))
         if job_ids:
             officer_query = officer_query.filter(Assignment.job_id.in_(job_ids))
     officer_query = officer_query.options(selectinload(Officer.assignments_lazy))

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -361,6 +361,7 @@ def filter_by_form(form_data, officer_query, department_id=None):
         ]
 
         if "Not Sure" in form_data["unit"]:
+            # Convert "Not Sure" to None, so the resulting SQL query allows NULL values
             form_data["unit"].append(None)
 
     if form_data.get("badge") or unit_ids or job_ids:

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -1654,6 +1654,7 @@ def test_browse_filtering_allows_good(client, mockdata, session):
         ]
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
         job = Job.query.filter_by(department_id=officer.department_id).first()
+        unit = Unit.query.filter_by(department_id=officer.department_id).first()
         form = AddOfficerForm(
             first_name="A",
             last_name="A",
@@ -1662,6 +1663,7 @@ def test_browse_filtering_allows_good(client, mockdata, session):
             gender="M",
             star_no=666,
             job_id=job.id,
+            unit=unit.id,
             department=department_id,
             birth_year=1990,
             links=links,
@@ -1695,13 +1697,17 @@ def test_browse_filtering_allows_good(client, mockdata, session):
             data=data,
             follow_redirects=True,
         )
-        filter_list = rv.data.decode("utf-8").split("<dt>Race</dt>")[1:]
-        assert any("<dd>White</dd>" in token for token in filter_list)
 
-        filter_list = rv.data.decode("utf-8").split("<dt>Job Title</dt>")[1:]
+        filter_list = rv.data.decode("utf-8").split("<dt>Rank</dt>")[1:]
         assert any(
             "<dd>{}</dd>".format(job.job_title) in token for token in filter_list
         )
+
+        filter_list = rv.data.decode("utf-8").split("<dt>Unit</dt>")[1:]
+        assert any("<dd>{}</dd>".format(unit.descrip) in token for token in filter_list)
+
+        filter_list = rv.data.decode("utf-8").split("<dt>Race</dt>")[1:]
+        assert any("<dd>White</dd>" in token for token in filter_list)
 
         filter_list = rv.data.decode("utf-8").split("<dt>Gender</dt>")[1:]
         assert any("<dd>Male</dd>" in token for token in filter_list)


### PR DESCRIPTION
## Description of Changes
This PR attempts to improve the unit and rank search filters by unifying their behavior and making them scrollable. OpenOversight was probably never intended for as many ranks/units we have (over 100). Currently the ranks are a multi-select checkbox list, while the units are a drop down list. This is quite cumbersome for users and prevents them from being able to select more than one unit.

I've modified the unit field so that it is also a multi-select checkbox list. When both of these search fields are opened the page becomes tremendously long rendering all of the results. In order to prevent this, I changed the frontend to allow scrolling overflow for these 2 options.

I also altered which fields show up in the officer list entry to better match which fields users can (and care about) searching against.

Lastly, I also moved the `currently_on_force` template filter added in #55 to a function on the `Officer` model (now that I had figured out where to add it!). This resolves #59.

This work is based off the request from #56, though I don't feel like a text search here would be appropriate. We want users to be able to select multiple ranks/units, but we also don't want to leave them guessing what the ranks & units are. This provides a suitable middle ground in my opinion: they don't have to know what the ranks/units a priori, and they can select multiple ranks/units when making a search.

## Notes for Deployment

## Screenshots (if appropriate)

### Before

#### List entry
![Screenshot_2021-12-29_08-46-29](https://user-images.githubusercontent.com/10214785/147685167-f946832b-0e4c-47fe-844f-b28dcac95c25.png)

#### Dropdowns

https://user-images.githubusercontent.com/10214785/147685251-0845f84b-d133-4efd-9a8e-382fb1edb147.mp4

### After

#### List entry
![Screenshot_2021-12-29_08-47-30](https://user-images.githubusercontent.com/10214785/147685280-8d9a9242-126d-4a6c-af82-b06a175a5ec7.png)


#### Dropdowns

https://user-images.githubusercontent.com/10214785/147685271-4067fd07-d80d-4d07-9573-975a788158eb.mp4


## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
