### PR TITLE
Keep filter field accordions open if in query

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -99,6 +99,14 @@ def create_app(config_name="default"):
         if birth_year:
             return int(datetime.datetime.now().year - birth_year)
 
+    @app.template_filter("field_in_query")
+    def field_in_query(form_data, field):
+        """
+        Determine if a field is specified in the form data, and if so return a Bootstrap
+        class which will render the field accordion open.
+        """
+        return " in " if form_data[field] else ""
+
     @app.template_filter("currently_on_force")
     def officer_currently_on_force(assignments):
         if not assignments:

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -105,7 +105,7 @@ def create_app(config_name="default"):
         Determine if a field is specified in the form data, and if so return a Bootstrap
         class which will render the field accordion open.
         """
-        return " in " if form_data[field] else ""
+        return " in " if field in form_data else ""
 
     @app.template_filter("currently_on_force")
     def officer_currently_on_force(assignments):

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -105,7 +105,7 @@ def create_app(config_name="default"):
         Determine if a field is specified in the form data, and if so return a Bootstrap
         class which will render the field accordion open.
         """
-        return " in " if field in form_data else ""
+        return " in " if form_data.get(field) else ""
 
     @app.template_filter("currently_on_force")
     def officer_currently_on_force(assignments):

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -120,7 +120,7 @@
           <div class="panel-heading{% if not form_data['unique_internal_identifier'] %} collapsed{% endif %}" data-toggle="collapse" data-target="#filter-unique_internal_identifier">
             <h3 class="panel-title accordion-toggle">Unique ID</h3>
           </div>
-          <div class="collapse{% if form_data['unique_internal_identifier'] %} in{% endif %}" id="filter-unique_internal_identifier">
+          <div class="collapse {{ form_data | field_in_query("unique_internal_identifier") }}" id="filter-unique_internal_identifier">
             <div class="panel-body">
               <div class="form-group">
                 <input type="text" class="form-control" id="unique_internal_identifier" name="unique_internal_identifier" value="{{ form_data['unique_internal_identifier'] or '' }}" />

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -49,7 +49,7 @@
           <div class="panel-heading" data-toggle="collapse" data-target="#filter-race">
             <h3 class="panel-title accordion-toggle">Race</h3>
           </div>
-          <div class="collapse" id="filter-race">
+          <div class="collapse {{ form_data | field_in_query("race") }}" id="filter-race">
             <div class="panel-body">
               <div class="form-group checkbox">
                 {% for choice in choices['race'] %}
@@ -65,7 +65,7 @@
           <div class="panel-heading" data-toggle="collapse" data-target="#filter-gender">
             <h3 class="panel-title accordion-toggle">Gender</h3>
           </div>
-          <div class="collapse" id="filter-gender">
+          <div class="collapse {{ form_data | field_in_query("gender") }}" id="filter-gender">
             <div class="panel-body">
               <div class="form-group radio">
                 {% for choice in choices['gender'] %}
@@ -81,7 +81,7 @@
           <div class="panel-heading" data-toggle="collapse" data-target="#filter-rank">
             <h3 class="panel-title accordion-toggle">Rank</h3>
           </div>
-          <div class="collapse" id="filter-rank">
+          <div class="collapse {{ form_data | field_in_query("rank") }}" id="filter-rank">
             <div class="panel-body">
               <div class="form-group checkbox">
                 {% for choice in choices['rank'] %}
@@ -97,7 +97,7 @@
           <div class="panel-heading" data-toggle="collapse" data-target="#filter-unit">
             <h3 class="panel-title accordion-toggle">Unit</h3>
           </div>
-          <div class="collapse" id="filter-unit">
+          <div class="collapse {{ form_data | field_in_query("unit") }}" id="filter-unit">
             <div class="panel-body">
               <div class="form-group">
                 <select class="form-control" name="unit">

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -34,18 +34,6 @@
           </div>
         </div>
         <div class="panel">
-          <div class="panel-heading{% if not form_data['unique_internal_identifier'] %} collapsed{% endif %}" data-toggle="collapse" data-target="#filter-unique_internal_identifier">
-            <h3 class="panel-title accordion-toggle">Unique ID</h3>
-          </div>
-          <div class="collapse{% if form_data['unique_internal_identifier'] %} in{% endif %}" id="filter-unique_internal_identifier">
-            <div class="panel-body">
-              <div class="form-group">
-                <input type="text" class="form-control" id="unique_internal_identifier" name="unique_internal_identifier" value="{{ form_data['unique_internal_identifier'] or '' }}" />
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="panel">
           <div class="panel-heading" data-toggle="collapse" data-target="#filter-race">
             <h3 class="panel-title accordion-toggle">Race</h3>
           </div>
@@ -124,6 +112,18 @@
                   <label>Max</label>
                   <input type="number" class="form-control" id="max_age" name="max_age" value="{{ form_data['max_age'] or 100 }}" />
                 </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="panel">
+          <div class="panel-heading{% if not form_data['unique_internal_identifier'] %} collapsed{% endif %}" data-toggle="collapse" data-target="#filter-unique_internal_identifier">
+            <h3 class="panel-title accordion-toggle">Unique ID</h3>
+          </div>
+          <div class="collapse{% if form_data['unique_internal_identifier'] %} in{% endif %}" id="filter-unique_internal_identifier">
+            <div class="panel-body">
+              <div class="form-group">
+                <input type="text" class="form-control" id="unique_internal_identifier" name="unique_internal_identifier" value="{{ form_data['unique_internal_identifier'] or '' }}" />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Description of Changes

Resolves #68

This PR adds a template filter which will detect if a field is present in the search query, and if so it keeps the accordion for that field open once the form is submitted. This will help make it so users don't have to constantly keep re-opening the fields and allow them to see what they've selected. I've done this for all but age, which get submitted on every request so it seems moot.

I also moved the "Unique ID" form field down to the bottom. We don't use these yet (or possibly at all) and it might be confusing to users.

## Notes for Deployment

## Screenshots (if appropriate)

### Before

#### Filter order
![Screenshot_2021-12-29_16-17-19](https://user-images.githubusercontent.com/10214785/147712313-150fb208-4542-4163-a83d-f72e0d3ea53d.png)

#### Behavior

https://user-images.githubusercontent.com/10214785/147712322-8336d61e-b424-4d35-8e20-ea7a97f9a18c.mp4


### After

#### Filter order
![Screenshot_2021-12-29_16-17-28](https://user-images.githubusercontent.com/10214785/147712318-953c1bb4-6b12-40d3-a999-ecb4004546dd.png)

#### Behavior

https://user-images.githubusercontent.com/10214785/147712324-bfaf0622-078f-4d38-b8d3-f35dd311d5b9.mp4


## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
