### PR TITLE
Show the placeholder image if officer has no photos

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -253,6 +253,11 @@ def officer_profile(officer_id):
         face_paths = []
         for face in faces:
             face_paths.append(serve_image(face.image.filepath))
+        if not face_paths:
+            # Add in the placeholder image if no faces are found
+            face_paths = [
+                url_for("static", filename="images/placeholder.png", _external=True)
+            ]
     except Exception:
         exception_type, value, full_tback = sys.exc_info()
         current_app.logger.error(

--- a/OpenOversight/app/templates/partials/officer_faces.html
+++ b/OpenOversight/app/templates/partials/officer_faces.html
@@ -1,12 +1,12 @@
 {% for path in paths %}
 
-{% if is_admin_or_coordinator %}
+{% if is_admin_or_coordinator and faces %}
   <a href="{{ url_for('main.display_tag', tag_id=faces[loop.index - 1].id) }}">
 {% endif %}
 
 <img class="officer-face" src="{{ path }}" alt="Submission">
 
-{% if is_admin_or_coordinator %}
+{% if is_admin_or_coordinator and faces %}
   </a>
 {% endif %}
 

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -9,6 +9,7 @@ from io import BytesIO
 import pytest
 from flask import current_app, url_for
 from mock import MagicMock, patch
+from sqlalchemy.sql.operators import Operators
 
 from OpenOversight.app.main.choices import GENDER_CHOICES, RACE_CHOICES
 from OpenOversight.app.main.forms import (
@@ -101,6 +102,30 @@ def test_user_can_access_officer_list(mockdata, client, session):
         rv = client.get(url_for("main.list_officer", department_id=2))
 
         assert "Officers" in rv.data.decode("utf-8")
+
+
+@pytest.mark.parametrize(
+    "filter_func, has_placeholder",
+    [
+        (Operators.__invert__, True),
+        (lambda x: x, False),
+    ],
+)
+def test_officer_appropriately_shows_placeholder(
+    filter_func, has_placeholder, mockdata, client, session
+):
+    with current_app.test_request_context():
+        officer = Officer.query.filter(filter_func(Officer.face.any())).first()
+        placeholder = url_for(
+            "static", filename="images/placeholder.png", _external=True
+        )
+
+        rv = client.get(
+            url_for("main.officer_profile", officer_id=officer.id),
+            follow_redirects=True,
+        )
+
+        assert (placeholder not in rv.data.decode("utf-8")) ^ has_placeholder
 
 
 def test_ac_can_access_admin_on_dept_officer_profile(mockdata, client, session):

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -107,7 +107,9 @@ def test_user_can_access_officer_list(mockdata, client, session):
 @pytest.mark.parametrize(
     "filter_func, has_placeholder",
     [
+        # Officer without faces should have placeholder
         (Operators.__invert__, True),
+        # Officer with faces should not have placeholder
         (lambda x: x, False),
     ],
 )
@@ -125,7 +127,7 @@ def test_officer_appropriately_shows_placeholder(
             follow_redirects=True,
         )
 
-        assert (placeholder not in rv.data.decode("utf-8")) ^ has_placeholder
+        assert (placeholder in rv.data.decode("utf-8")) == has_placeholder
 
 
 def test_ac_can_access_admin_on_dept_officer_profile(mockdata, client, session):

--- a/justfile
+++ b/justfile
@@ -71,8 +71,8 @@ lint:
     pre-commit run --all-files
 
 # Run tests in the web container
-test:
-    @just run --no-deps web pytest
+test *pytestargs:
+    @just run --no-deps web pytest {{ pytestargs }}
 
 # Back up the postgres data using loomchild/volume-backup
 backup location:


### PR DESCRIPTION
## Description of Changes
This PR changes the officer page so that if an officer doesn't have any uploaded images the placeholder image will be displayed. Previously the section would just be blank, which would be a bit jarring since the placeholder exists on the list view.

## Notes for Deployment

## Screenshots (if appropriate)

### Before
![image](https://user-images.githubusercontent.com/10214785/147722654-7e324b45-4060-4173-bed3-44b616346313.png)

### After
![image](https://user-images.githubusercontent.com/10214785/147722676-6c57c895-470a-4d15-8962-696108621772.png)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
