### PR TITLE
Move pytest.ini to mounted folder, change pytest cache dir

### DIFF
--- a/OpenOversight/pytest.ini
+++ b/OpenOversight/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+cache_dir = /tmp
 env =
     FLASK_ENV=testing
     FLASK_APP=OpenOversight/app:app


### PR DESCRIPTION
## Description of Changes
This PR fixes an issue I've been experiencing where running `pytest` in the container will create a `.pytest_cache` folder as `root` which prevents the container from being rebuilt.

```
$ just build
docker-compose --file=docker-compose.yml --file=docker-compose.dev.yml build
postgres uses an image, skipping
minio uses an image, skipping
createbucket uses an image, skipping
Building web
error checking context: 'can't stat '/home/aether/git/OpenOversight/OpenOversight/.pytest_cache''.
ERROR: Service 'web' failed to build
error: Recipe `build` failed on line 21 with exit code 1
```

This PR changes the cache directory to something that isn't mounted.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
