### PR TITLE
Fixes #98: Cannot open Account navbar menu when on an officer page

### DIFF
--- a/OpenOversight/app/templates/partials/incident_fields.html
+++ b/OpenOversight/app/templates/partials/incident_fields.html
@@ -89,7 +89,5 @@
 </table>
 
 {% block js_footer %}
-	<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
-	<script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
 	<script src="{{ url_for('static', filename='js/incidentDescription.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Description of Changes
Fixes #98.

The bootstrap.min.js file was imported a second time in the incident_fields.html template a second time (first imported in base.html), which caused it to register the dropdown event listener twice. So what was happening was the dropdown was triggering twice, fast enough that it looked like nothing was happening.

Also confirmed that all pages that include incident_fields.html directly or indirectly extend base.html:
```
OpenOversight/app/templates/incident_detail.html
OpenOversight/app/templates/incident_list.html
OpenOversight/app/templates/partials/officer_incidents.html
```

## Notes for Deployment

## Screenshots (if appropriate)
![screenshot](https://user-images.githubusercontent.com/66500457/147979338-edd2809f-14b6-4b3c-9f75-f3133d03ad5d.png)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
