### PR TITLE
Make emails case-insensitive for user operations

### DIFF
--- a/OpenOversight/app/auth/forms.py
+++ b/OpenOversight/app/auth/forms.py
@@ -46,11 +46,11 @@ class RegistrationForm(Form):
     submit = SubmitField("Register")
 
     def validate_email(self, field):
-        if User.query.filter_by(email=field.data).first():
+        if User.by_email(field.data).first():
             raise ValidationError("Email already registered.")
 
     def validate_username(self, field):
-        if User.query.filter_by(username=field.data).first():
+        if User.by_username(field.data).first():
             raise ValidationError("Username already in use.")
 
 
@@ -86,7 +86,7 @@ class PasswordResetForm(Form):
     submit = SubmitField("Reset Password")
 
     def validate_email(self, field):
-        if User.query.filter_by(email=field.data).first() is None:
+        if User.by_email(field.data).first() is None:
             raise ValidationError("Unknown email address.")
 
 
@@ -98,7 +98,7 @@ class ChangeEmailForm(Form):
     submit = SubmitField("Update Email Address")
 
     def validate_email(self, field):
-        if User.query.filter_by(email=field.data).first():
+        if User.by_email(field.data).first():
             raise ValidationError("Email already registered.")
 
 

--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -60,7 +60,7 @@ def unconfirmed():
 def login():
     form = LoginForm()
     if form.validate_on_submit():
-        user = User.query.filter_by(email=form.email.data).first()
+        user = User.by_email(form.email.data).first()
         if user is not None and user.verify_password(form.password.data):
             login_user(user, form.remember_me.data)
             return redirect(request.args.get("next") or url_for("main.index"))
@@ -183,7 +183,7 @@ def password_reset_request():
         return redirect(url_for("main.index"))
     form = PasswordResetRequestForm()
     if form.validate_on_submit():
-        user = User.query.filter_by(email=form.email.data).first()
+        user = User.by_email(form.email.data).first()
         if user:
             token = user.generate_reset_token()
             send_email(
@@ -209,7 +209,7 @@ def password_reset(token):
         return redirect(url_for("main.index"))
     form = PasswordResetForm()
     if form.validate_on_submit():
-        user = User.query.filter_by(email=form.email.data).first()
+        user = User.by_email(form.email.data).first()
         if user is None:
             return redirect(url_for("main.index"))
         if user.reset_password(token, form.password.data):

--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -23,7 +23,7 @@ def make_admin_user():
     """Add confirmed administrator account."""
     while True:
         username = input("Username: ")
-        user = User.query.filter_by(username=username).one_or_none()
+        user = User.by_username(username).one_or_none()
         if user:
             print("Username is already in use")
         else:
@@ -31,7 +31,7 @@ def make_admin_user():
 
     while True:
         email = input("Email: ")
-        user = User.query.filter_by(email=email).one_or_none()
+        user = User.by_email(email).one_or_none()
         if user:
             print("Email address already in use")
         else:

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -173,7 +173,7 @@ def get_ooid():
 def get_started_labeling():
     form = LoginForm()
     if form.validate_on_submit():
-        user = User.query.filter_by(email=form.email.data).first()
+        user = User.by_email(form.email.data).first()
         if user is not None and user.verify_password(form.password.data):
             login_user(user, form.remember_me.data)
             return redirect(request.args.get("next") or url_for("main.index"))
@@ -212,7 +212,7 @@ def get_tutorial():
 @login_required
 def profile(username):
     if re.search("^[A-Za-z][A-Za-z0-9_.]*$", username):
-        user = User.query.filter_by(username=username).one()
+        user = User.by_username(username).one()
     else:
         abort(404)
     try:

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -6,7 +6,7 @@ from flask_login import UserMixin
 from flask_sqlalchemy import SQLAlchemy
 from itsdangerous import BadData, BadSignature
 from itsdangerous import TimedJSONWebSignatureSerializer as Serializer
-from sqlalchemy import CheckConstraint, UniqueConstraint
+from sqlalchemy import CheckConstraint, UniqueConstraint, func
 
 # from flask_sqlalchemy.model import DefaultMeta
 from sqlalchemy.orm import validates
@@ -517,6 +517,12 @@ class User(UserMixin, BaseModel):
     @password.setter
     def password(self, password):
         self.password_hash = generate_password_hash(password, method="pbkdf2:sha256")
+
+    def by_email(email):
+        return User.query.filter(func.lower(User.email) == func.lower(email))
+
+    def by_username(username):
+        return User.query.filter(func.lower(User.username) == func.lower(username))
 
     def verify_password(self, password):
         return check_password_hash(self.password_hash, password)

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -518,14 +518,17 @@ class User(UserMixin, BaseModel):
     def password(self, password):
         self.password_hash = generate_password_hash(password, method="pbkdf2:sha256")
 
+    @staticmethod
     def _case_insensitive_equality(field, value):
         return User.query.filter(func.lower(field) == func.lower(value))
 
+    @staticmethod
     def by_email(email):
-        return self._case_insensitive_equality(User.email, email)
+        return User._case_insensitive_equality(User.email, email)
 
+    @staticmethod
     def by_username(username):
-        return self._case_insensitive_equality(User.username, username)
+        return User._case_insensitive_equality(User.username, username)
 
     def verify_password(self, password):
         return check_password_hash(self.password_hash, password)

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -518,11 +518,14 @@ class User(UserMixin, BaseModel):
     def password(self, password):
         self.password_hash = generate_password_hash(password, method="pbkdf2:sha256")
 
+    def _case_insensitive_equality(field, value):
+        return User.query.filter(func.lower(field) == func.lower(value))
+
     def by_email(email):
-        return User.query.filter(func.lower(User.email) == func.lower(email))
+        return _case_insensitive_equality(User.email, email)
 
     def by_username(username):
-        return User.query.filter(func.lower(User.username) == func.lower(username))
+        return _case_insensitive_equality(User.username, username)
 
     def verify_password(self, password):
         return check_password_hash(self.password_hash, password)

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -522,10 +522,10 @@ class User(UserMixin, BaseModel):
         return User.query.filter(func.lower(field) == func.lower(value))
 
     def by_email(email):
-        return _case_insensitive_equality(User.email, email)
+        return self._case_insensitive_equality(User.email, email)
 
     def by_username(username):
-        return _case_insensitive_equality(User.username, username)
+        return self._case_insensitive_equality(User.username, username)
 
     def verify_password(self, password):
         return check_password_hash(self.password_hash, password)

--- a/OpenOversight/tests/routes/test_other.py
+++ b/OpenOversight/tests/routes/test_other.py
@@ -36,3 +36,18 @@ def test_user_can_access_profile(mockdata, client, session):
         assert "User Email" not in rv.data.decode("utf-8")
         # Toggle button should not appear for this non-admin user
         assert "Edit User" not in rv.data.decode("utf-8")
+
+
+def test_user_can_access_profile_differently_cased(mockdata, client, session):
+    with current_app.test_request_context():
+        login_user(client)
+
+        rv = client.get(
+            url_for("main.profile", username="TEST_USER"), follow_redirects=True
+        )
+        assert "test_user" in rv.data.decode("utf-8")
+        assert "User Email" not in rv.data.decode("utf-8")
+        assert "Edit User" not in rv.data.decode("utf-8")
+
+        # Should use username in db
+        assert "TEST_USER" not in rv.data.decode("utf-8")


### PR DESCRIPTION
## Description of Changes
Fixes #79.

This looks similar to [this issue](https://github.com/mattupstate/flask-security/issues/323) in that we actually need to worry about case-sensitivity since we're using Postgres.

This change just replaces all the places in the code that filter by email/username with new functions `by_email`/`by_username` that lowercase the values before performing the comparison.

## Notes for Deployment
Someone with DB access will have to check that there aren't any users with the same but differently cased emails set

## Screenshots (if appropriate)
None that I can think of!

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
