### PR TITLE
Automatically send confirmation email when a user is approved

### DIFF
--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -319,7 +319,17 @@ def edit_user(user_id):
                 form.populate_obj(user)
                 db.session.add(user)
                 db.session.commit()
+
+                # automatically send a confirmation email when approving an unconfirmed user
+                if (
+                    not (current_user.approved)
+                    and user.approved
+                    and not (user.confirmed)
+                ):
+                    admin_resend_confirmation(user)
+
                 flash("{} has been updated!".format(user.username))
+
                 return redirect(url_for("auth.edit_user", user_id=user.id))
             else:
                 flash("Invalid entry")

--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -316,16 +316,13 @@ def edit_user(user_id):
                     flash("You cannot edit your own account!")
                     form = EditUserForm(obj=user)
                     return render_template("auth/user.html", user=user, form=form)
+                already_approved = user.approved
                 form.populate_obj(user)
                 db.session.add(user)
                 db.session.commit()
 
                 # automatically send a confirmation email when approving an unconfirmed user
-                if (
-                    not (current_user.approved)
-                    and user.approved
-                    and not (user.confirmed)
-                ):
+                if not already_approved and user.approved and not user.confirmed:
                     admin_resend_confirmation(user)
 
                 flash("{} has been updated!".format(user.username))

--- a/OpenOversight/tests/routes/test_user_api.py
+++ b/OpenOversight/tests/routes/test_user_api.py
@@ -315,3 +315,71 @@ def test_admin_can_approve_user(mockdata, client, session):
 
         user = User.query.get(user_id)
         assert user.approved
+
+
+def test_admin_approving_unconfirmed_user_sends_confirmation_email(
+    mockdata, client, session
+):
+    with current_app.test_request_context():
+        login_admin(client)
+
+        user = User.query.filter_by(is_administrator=False).first()
+        user_id = user.id
+        user.approved = False
+        user.confirmed = False
+        db.session.commit()
+
+        user = User.query.get(user_id)
+        assert not user.approved
+        assert not user.confirmed
+
+        form = EditUserForm(
+            approved=True,
+            submit=True,
+        )
+
+        rv = client.post(
+            url_for("auth.edit_user", user_id=user_id),
+            data=form.data,
+            follow_redirects=True,
+        )
+
+        assert "new confirmation email" in rv.data.decode("utf-8")
+        assert "updated!" in rv.data.decode("utf-8")
+
+        user = User.query.get(user_id)
+        assert user.approved
+
+
+def test_admin_approving_confirmed_user_does_not_send_confirmation_email(
+    mockdata, client, session
+):
+    with current_app.test_request_context():
+        login_admin(client)
+
+        user = User.query.filter_by(is_administrator=False).first()
+        user_id = user.id
+        user.approved = False
+        user.confirmed = True
+        db.session.commit()
+
+        user = User.query.get(user_id)
+        assert not user.approved
+        assert user.confirmed
+
+        form = EditUserForm(
+            approved=True,
+            submit=True,
+        )
+
+        rv = client.post(
+            url_for("auth.edit_user", user_id=user_id),
+            data=form.data,
+            follow_redirects=True,
+        )
+
+        assert "new confirmation email" not in rv.data.decode("utf-8")
+        assert "updated!" in rv.data.decode("utf-8")
+
+        user = User.query.get(user_id)
+        assert user.approved


### PR DESCRIPTION
## Description of Changes
Fixes #80.

Automatically send confirmation email when a user is approved, if they are not confirmed already

## Notes for Deployment
None!

## Screenshots (if appropriate)
![confirmation_email](https://user-images.githubusercontent.com/66500457/148158692-ad08e9da-e07e-43ab-9ce1-e9506b7e7ee3.png)


## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
