### PR TITLE
Replace itsdangerous JWS with authlib

### DIFF
--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -1,11 +1,11 @@
 import re
+import time
 from datetime import date
 
+from authlib.jose import JoseError, JsonWebToken
 from flask import current_app
 from flask_login import UserMixin
 from flask_sqlalchemy import SQLAlchemy
-from itsdangerous import BadData, BadSignature
-from itsdangerous import TimedJSONWebSignatureSerializer as Serializer
 from sqlalchemy import CheckConstraint, UniqueConstraint, func
 
 # from flask_sqlalchemy.model import DefaultMeta
@@ -17,6 +17,7 @@ from .validators import state_validator, url_validator
 
 
 db = SQLAlchemy()
+jwt = JsonWebToken("HS512")
 
 BaseModel = (
     db.Model
@@ -510,6 +511,20 @@ class User(UserMixin, BaseModel):
     classifications = db.relationship("Image", backref="users")
     tags = db.relationship("Face", backref="users")
 
+    def _jwt_encode(self, secret, payload, expiration):
+        header = {"alg": "HS512"}
+
+        now = int(time.time())
+        payload["iat"] = now
+        payload["exp"] = now + expiration
+
+        return jwt.encode(header, payload, secret)
+
+    def _jwt_decode(self, secret, token):
+        token = jwt.decode(token, secret)
+        token.validate()
+        return token
+
     @property
     def password(self):
         raise AttributeError("password is not a readable attribute")
@@ -534,14 +549,14 @@ class User(UserMixin, BaseModel):
         return check_password_hash(self.password_hash, password)
 
     def generate_confirmation_token(self, expiration=3600):
-        s = Serializer(current_app.config["SECRET_KEY"], expiration)
-        return s.dumps({"confirm": self.id}).decode("utf-8")
+        key = current_app.config["SECRET_KEY"]
+        payload = {"confirm": self.id}
+        return self._jwt_encode(key, payload, expiration).decode("utf-8")
 
     def confirm(self, token):
-        s = Serializer(current_app.config["SECRET_KEY"])
         try:
-            data = s.loads(token)
-        except (BadSignature, BadData) as e:
+            data = self._jwt_decode(current_app.config["SECRET_KEY"], token)
+        except JoseError as e:
             current_app.logger.warning("failed to decrypt token: %s", e)
             return False
         if data.get("confirm") != self.id:
@@ -555,14 +570,14 @@ class User(UserMixin, BaseModel):
         return True
 
     def generate_reset_token(self, expiration=3600):
-        s = Serializer(current_app.config["SECRET_KEY"], expiration)
-        return s.dumps({"reset": self.id}).decode("utf-8")
+        key = current_app.config["SECRET_KEY"]
+        payload = {"reset": self.id}
+        return self._jwt_encode(key, payload, expiration).decode("utf-8")
 
     def reset_password(self, token, new_password):
-        s = Serializer(current_app.config["SECRET_KEY"])
         try:
-            data = s.loads(token)
-        except (BadSignature, BadData):
+            data = self._jwt_decode(current_app.config["SECRET_KEY"], token)
+        except JoseError:
             return False
         if data.get("reset") != self.id:
             return False
@@ -571,16 +586,14 @@ class User(UserMixin, BaseModel):
         return True
 
     def generate_email_change_token(self, new_email, expiration=3600):
-        s = Serializer(current_app.config["SECRET_KEY"], expiration)
-        return s.dumps({"change_email": self.id, "new_email": new_email}).decode(
-            "utf-8"
-        )
+        key = current_app.config["SECRET_KEY"]
+        payload = {"change_email": self.id, "new_email": new_email}
+        return self._jwt_encode(key, payload, expiration).decode("utf-8")
 
     def change_email(self, token):
-        s = Serializer(current_app.config["SECRET_KEY"])
         try:
-            data = s.loads(token)
-        except (BadSignature, BadData):
+            data = self._jwt_decode(current_app.config["SECRET_KEY"], token)
+        except JoseError:
             return False
         if data.get("change_email") != self.id:
             return False

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -167,9 +167,7 @@ def test_expired_reset_token(mockdata):
     assert user.verify_password("bacon") is True
 
 
-def test_valid_email_change_token(
-    old_email, new_email, result, expected_email, mockdata
-):
+def test_valid_email_change_token(mockdata):
     user = User(email="brian@example.com", password="bacon")
     db.session.add(user)
     db.session.commit()

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -158,13 +158,33 @@ def test_invalid_reset_token(mockdata):
     assert user2.verify_password("vegan bacon") is True
 
 
-def test_valid_email_change_token(mockdata):
+def test_expired_reset_token(mockdata):
+    user = User(password="bacon")
+    db.session.add(user)
+    db.session.commit()
+    token = user.generate_reset_token(expiration=-1)
+    assert user.reset_password(token, "tempeh") is False
+    assert user.verify_password("bacon") is True
+
+
+def test_valid_email_change_token(
+    old_email, new_email, result, expected_email, mockdata
+):
     user = User(email="brian@example.com", password="bacon")
     db.session.add(user)
     db.session.commit()
     token = user.generate_email_change_token("lucy@example.org")
     assert user.change_email(token) is True
     assert user.email == "lucy@example.org"
+
+
+def test_email_change_token_no_email(mockdata):
+    user = User(email="brian@example.com", password="bacon")
+    db.session.add(user)
+    db.session.commit()
+    token = user.generate_email_change_token(None)
+    assert user.change_email(token) is False
+    assert user.email == "brian@example.com"
 
 
 def test_invalid_email_change_token(mockdata):
@@ -176,6 +196,15 @@ def test_invalid_email_change_token(mockdata):
     token = user1.generate_email_change_token("mason@example.net")
     assert user2.change_email(token) is False
     assert user2.email == "freddy@example.com"
+
+
+def test_expired_email_change_token(mockdata):
+    user = User(email="jen@example.com", password="cat")
+    db.session.add(user)
+    db.session.commit()
+    token = user.generate_email_change_token("mason@example.net", expiration=-1)
+    assert user.change_email(token) is False
+    assert user.email == "jen@example.com"
 
 
 def test_duplicate_email_change_token(mockdata):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Authlib==0.15.5
 boto3==1.17.101
 email-validator==1.0.5
 Fabric3==1.14.post1


### PR DESCRIPTION
## Description of Changes
Fixes #85.

Replace deprecated itsdangerous JWS with authlib

OpenOversight currently uses itsdangerous `TimedJSONWebSignatureSerializer` to generate what are basically JWTs for email confirmation/email change/password reset. This change replaces itsdangerous JWS with authlib JWT.

## Notes for Deployment
There's a slight mismatch between the itsdangerous JWS and authlib JWT implementations where itsdangerous sets `iat` (issued-at time) and `exp` (expiration) in the header instead of the payload. This means that tokens generated before this change is deployed will fail if used after this deployment. To fix this, just request another token

## Screenshots (if appropriate)
N/A

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
