### PR TITLE
Display readable errors instead of html

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -82,7 +82,6 @@ def create_app(config_name="default"):
         :param error: response error message, if JSON
         :param template: template response
         """
-
         def _handler_method(e):
             if request.accept_mimetypes.best == "application/json":
                 return jsonify(error=error), code
@@ -98,6 +97,7 @@ def create_app(config_name="default"):
         (500, "Internal Server Error", "500.html"),
     ]
     for code, error, template in error_handlers:
+        # Pass generated errorhandler function to @app.errorhandler decorator
         app.errorhandler(code)(create_errorhandler(code, error, template))
 
     # create jinja2 filter for titles with multiple capitals

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -82,6 +82,7 @@ def create_app(config_name="default"):
         :param error: response error message, if JSON
         :param template: template response
         """
+
         def _handler_method(e):
             if request.accept_mimetypes.best == "application/json":
                 return jsonify(error=error), code

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -3,7 +3,7 @@ import logging
 import os
 from logging.handlers import RotatingFileHandler
 
-from flask import Flask, render_template, request
+from flask import Flask, jsonify, render_template, request
 from flask_bootstrap import Bootstrap
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
@@ -73,21 +73,32 @@ def create_app(config_name="default"):
     # Also log when endpoints are getting hit hard
     limiter.logger.addHandler(file_handler)
 
-    @app.errorhandler(404)
-    def page_not_found(e):
-        return render_template("404.html"), 404
+    # Define error handlers
+    def create_errorhandler(code, error, template):
+        """
+        Create an error handler that returns a JSON or a template response
+        based on the request "Accept" header.
+        :param code: status code to handle
+        :param error: response error message, if JSON
+        :param template: template response
+        """
 
-    @app.errorhandler(403)
-    def forbidden(e):
-        return render_template("403.html"), 403
+        def _handler_method(e):
+            if request.accept_mimetypes.best == "application/json":
+                return jsonify(error=error), code
+            return render_template(template), code
 
-    @app.errorhandler(500)
-    def internal_error(e):
-        return render_template("500.html"), 500
+        return _handler_method
 
-    @app.errorhandler(429)
-    def rate_exceeded(e):
-        return render_template("429.html"), 429
+    error_handlers = [
+        (403, "Forbidden", "403.html"),
+        (404, "Not found", "404.html"),
+        (413, "File too large", "413.html"),
+        (429, "Too many requests", "429.html"),
+        (500, "Internal Server Error", "500.html"),
+    ]
+    for code, error, template in error_handlers:
+        app.errorhandler(code)(create_errorhandler(code, error, template))
 
     # create jinja2 filter for titles with multiple capitals
     @app.template_filter("capfirst")

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1307,9 +1307,14 @@ def upload(department_id, officer_id=None):
     file_to_upload = request.files["file"]
     if not allowed_file(file_to_upload.filename):
         return jsonify(error="File type not allowed!"), 415
-    image = upload_image_to_s3_and_store_in_db(
-        file_to_upload, current_user.get_id(), department_id=department_id
-    )
+
+    try:
+        image = upload_image_to_s3_and_store_in_db(
+            file_to_upload, current_user.get_id(), department_id=department_id
+        )
+    except ValueError:
+        # Raised if MIME type not allowed
+        return jsonify(error="Invalid data type!"), 415
 
     if image:
         db.session.add(image)

--- a/OpenOversight/app/static/js/init-dropzone.js
+++ b/OpenOversight/app/static/js/init-dropzone.js
@@ -1,0 +1,36 @@
+/**
+ * Initialize dropzone component
+ * @param id element id
+ * @param url url to upload to
+ * @param csrf_token CSRF token
+ * @return the Dropzone object
+ */
+function init_dropzone(id, url, csrf_token) {
+    Dropzone.autoDiscover = false;
+
+    let myDropzone = new Dropzone(id, {
+      url: url,
+      method: "POST",
+      uploadMultiple: false,
+      parallelUploads: 50,
+      acceptedFiles: "image/png, image/jpeg, image/gif, image/jpg, image/webp",
+      maxFiles: 50,
+      headers: {
+        'Accept': 'application/json',
+        'X-CSRF-TOKEN': csrf_token
+      },
+      init: function() {
+        this.on("error", function(file, response) {
+          if (typeof(response) == "object") {
+            response = response.error;
+          }
+          if (response.startsWith("<!DOCTYPE")) {
+            // Catch any remaining HTML error pages
+            response = "Upload failed.";
+          }
+          file.previewTemplate.appendChild(document.createTextNode(response));
+        });
+      }
+    });
+    return myDropzone;
+}

--- a/OpenOversight/app/templates/413.html
+++ b/OpenOversight/app/templates/413.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}File Too Large{% endblock %}
+
+{% block content %}
+
+<div class="container theme-showcase" role="main">
+
+<h1>File Too Large</h1>
+<p>The file you are trying to upload is too large. <a href="{{ url_for('main.index') }}">Return to homepage</a>.</p>
+
+</div>
+{% endblock %}

--- a/OpenOversight/app/templates/submit_image.html
+++ b/OpenOversight/app/templates/submit_image.html
@@ -46,6 +46,7 @@
 
     <script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/dropzone.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/init-dropzone.js') }}"></script>
 
     <script>
         // Select user's preferred department by default
@@ -63,35 +64,8 @@
             });
         });
 
-        Dropzone.autoDiscover = false;
-        const getURL = (file) => {
-            return "/upload/department/" + dept_id;
-        }
-
-        let myDropzone = new Dropzone("#my-cop-dropzone", {
-            method: "post",
-            url: getURL,
-            uploadMultiple: false,
-            parallelUploads: 50,
-            acceptedFiles: "image/png, image/jpeg, image/gif, image/jpg, image/webp",
-            maxFiles: 50,
-            headers: {
-                'Accept': 'application/json',
-                'X-CSRF-TOKEN': csrf_token
-            },
-            init: function() {
-              this.on("error", function(file, response) {
-                if (typeof(response) == 'object') {
-                  response = response.error;
-                }
-                if (response.startsWith("<!DOCTYPE")) {
-                  // Catch any remaining HTML error pages
-                  response = "Upload failed.";
-                }
-                file.previewTemplate.appendChild(document.createTextNode(response));
-              });
-            }
-        });
+        const getURL = (file) => "/upload/department/" + dept_id;
+        init_dropzone("#my-cop-dropzone", getURL, csrf_token);
     </script>
 </div>
 

--- a/OpenOversight/app/templates/submit_image.html
+++ b/OpenOversight/app/templates/submit_image.html
@@ -76,12 +76,20 @@
             acceptedFiles: "image/png, image/jpeg, image/gif, image/jpg, image/webp",
             maxFiles: 50,
             headers: {
+                'Accept': 'application/json',
                 'X-CSRF-TOKEN': csrf_token
             },
             init: function() {
-                this.on("error", function(file, responseText) {
-                    file.previewTemplate.appendChild(document.createTextNode(responseText));
-                });
+              this.on("error", function(file, response) {
+                if (typeof(response) == 'object') {
+                  response = response.error;
+                }
+                if (response.startsWith("<!DOCTYPE")) {
+                  // Catch any remaining HTML error pages
+                  response = "Upload failed.";
+                }
+                file.previewTemplate.appendChild(document.createTextNode(response));
+              });
             }
         });
     </script>

--- a/OpenOversight/app/templates/submit_officer_image.html
+++ b/OpenOversight/app/templates/submit_officer_image.html
@@ -39,11 +39,19 @@
       acceptedFiles: "image/png, image/jpeg, image/gif, image/jpg",
       maxFiles: 50,
       headers: {
+        'Accept': 'application/json',
         'X-CSRF-TOKEN': csrf_token
       },
       init: function() {
-        this.on("error", function(file, responseText) {
-          file.previewTemplate.appendChild(document.createTextNode(responseText));
+        this.on("error", function(file, response, test) {
+          if (typeof(response) == "object") {
+            response = response.error;
+          }
+          if (response.startsWith("<!DOCTYPE")) {
+            // Catch any remaining HTML error pages
+            response = "Upload failed.";
+          }
+          file.previewTemplate.appendChild(document.createTextNode(response));
         });
       }
     });

--- a/OpenOversight/app/templates/submit_officer_image.html
+++ b/OpenOversight/app/templates/submit_officer_image.html
@@ -28,32 +28,13 @@
 {% block js_footer %}
   <script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
   <script src="{{ url_for('static', filename='js/dropzone.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/init-dropzone.js') }}"></script>
   <script>
     var csrf_token = "{{ csrf_token() }}";
-    Dropzone.autoDiscover = false;
-    let myDropzone = new Dropzone("#my-cop-dropzone", {
-      url: "/upload/department/{{ officer.department_id }}/officer/{{ officer.id }}",
-      method: "POST",
-      uploadMultiple: false,
-      parallelUploads: 50,
-      acceptedFiles: "image/png, image/jpeg, image/gif, image/jpg",
-      maxFiles: 50,
-      headers: {
-        'Accept': 'application/json',
-        'X-CSRF-TOKEN': csrf_token
-      },
-      init: function() {
-        this.on("error", function(file, response, test) {
-          if (typeof(response) == "object") {
-            response = response.error;
-          }
-          if (response.startsWith("<!DOCTYPE")) {
-            // Catch any remaining HTML error pages
-            response = "Upload failed.";
-          }
-          file.previewTemplate.appendChild(document.createTextNode(response));
-        });
-      }
-    });
+    init_dropzone(
+      "#my-cop-dropzone",
+      "/upload/department/{{ officer.department_id }}/officer/{{ officer.id }}",
+      csrf_token
+    );
   </script>
 {% endblock %}


### PR DESCRIPTION
## Description of Changes
Fixes #36.

Displays readable upload errors instead of spewing html.

* Added json error handlers for requests with "Accept: application/json" headers
* Added a default error message if the server still sends an html error response

## Notes for Deployment
None!

## Screenshots (if appropriate)
Errors shown when upload failed due to:
- internal server error
- file too large
- file type not allowed

![err1](https://user-images.githubusercontent.com/66500457/148666046-5b562a7e-5f01-4fe9-bf9a-a878c8e89f7a.png)

When an html error is received, the caption is set to "Upload failed." but if you hover over it you still get a bunch of html. This seems to be set in the dropzone library and there's not much we can do about it

![err2](https://user-images.githubusercontent.com/66500457/148666095-2f38bedf-7895-4f0c-b871-b161420e2c36.png)


## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
