### PR TITLE
Make incomplete salary more generic, since it's past 2021 now

### DIFF
--- a/OpenOversight/app/templates/partials/officer_salary.html
+++ b/OpenOversight/app/templates/partials/officer_salary.html
@@ -21,7 +21,7 @@
                         <td>{{ '${:,.2f}'.format(salary.overtime_pay) }}</td>
                         <td>{{ '${:,.2f}'.format(total) }}</td>
                     {% elif salary.overtime_pay < 0 %}
-                        <td>(year incomplete)</td>
+                        <td>(data incomplete)</td>
                         <td></td>
                     {% else %}
                         <td>$0</td>


### PR DESCRIPTION
## Description of Changes

This PR updates the salary condition for when the data is in complete. Previously this would show up as `year incomplete`. Now that it's past 2021, the year is incomplete but the data we have is not, so I've changed this to `data incomplete`.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
