### PR TITLE
Move links section to after incidents

### DIFF
--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -116,9 +116,6 @@
       {% if is_admin_or_coordinator %}
         {% include "partials/officer_notes.html" %}
       {% endif %}
-      {% with obj=officer %}
-        {% include "partials/links_and_videos_row.html" %}
-      {% endwith %}
     </div> {# end col #}
 
     <div class='col-sm-12 col-md-6'>
@@ -128,6 +125,9 @@
       {% if officer.incidents or is_admin_or_coordinator %}
         {% include "partials/officer_incidents.html" %}
       {% endif %}
+      {% with obj=officer %}
+        {% include "partials/links_and_videos_row.html" %}
+      {% endwith %}
     </div>{# end col #}
 
   </div> {# end row #}


### PR DESCRIPTION
## Description of Changes

On mobile, the `Links` section comes up before `Incidents`. This can be misleading for users since links are external whereas incidents links to further information internally.

For that reason, I've moved links _after_ incidents.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
