### PR TITLE
Improve cutoff for incident descriptions

### DIFF
--- a/OpenOversight/app/static/js/incidentDescription.js
+++ b/OpenOversight/app/static/js/incidentDescription.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
-    let overflow_length = 500;
+    let overflow_length = 700;
     $(".incident-description").each(function () {
         let description = this;
         let incidentId = $( this ).data("incident");
@@ -8,7 +8,16 @@ $(document).ready(function() {
         }
         if(description.innerHTML.length > overflow_length) {
             let originalDescription = description.innerHTML;
-            description.innerHTML = description.innerHTML.substring(0, overflow_length) + "…";
+            // Convert the innerHTML into a string, and truncate it to overflow length
+            const sub = description.innerHTML.substring(0, overflow_length)
+            // In order to make the cutoff clean, we will want to truncate *after*
+            // the end of the last HTML tag. So first we need to find the last tag.
+            const cutoff = sub.lastIndexOf("</")
+            // Tags could be variable length, so next find the index of the first
+            // ">" after the start of the closing bracket.
+            const lastTag = sub.substring(cutoff).indexOf(">")
+            // Lastly, trim the HTML to the end of the closing tag
+            description.innerHTML = sub.substring(0, cutoff + lastTag + 1) + "…";
             $(`#description-overflow-button_${incidentId}`).on('click', function(event) {
                 event.stopImmediatePropagation();
                 description.innerHTML = originalDescription;

--- a/OpenOversight/app/templates/partials/incident_fields.html
+++ b/OpenOversight/app/templates/partials/incident_fields.html
@@ -90,7 +90,3 @@
   {% endif %}
   </tbody>
 </table>
-
-{% block js_footer %}
-  <script src="{{ url_for('static', filename='js/incidentDescription.js') }}"></script>
-{% endblock %}

--- a/OpenOversight/app/templates/partials/officer_incidents.html
+++ b/OpenOversight/app/templates/partials/officer_incidents.html
@@ -17,6 +17,9 @@
         </li>
     {% endfor %}
     </ul>
+  {% block js_footer %}
+    <script src="{{ url_for('static', filename='js/incidentDescription.js') }}"></script>
+  {% endblock %}
 {% endif %}
 {% if is_admin_or_coordinator %}
     <a href="{{ url_for('main.incident_api') + 'new?officer_id={}'.format(officer.id) }}" class='btn btn-primary'>New Incident</a>

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -14,7 +14,7 @@ from OpenOversight.app.config import BaseConfig
 from OpenOversight.app.models import Department, Incident, Officer, Unit, db
 
 
-DESCRIPTION_CUTOFF = 500
+DESCRIPTION_CUTOFF = 700
 
 
 @contextmanager


### PR DESCRIPTION
## Description of Changes

This PR addresses a few issues with the incident cutoff. The `incidentDescription.js` file was being included multiple times, and so the buttons would disappear altogether in some cases (this is similar to #100).

I've also modified the logic that was doing the truncation. In #99, I changed the description cutoff so that it used `innerHTML` rather than `innerText`. I didn't account for the fact that performing a substring operation on `innerHTML` might cut the HTML off in the middle of a tag. The change to this logic makes it so that the end of the last tag before the cutoff is used as the cutoff instead, so the descriptions are a bit cleaner.

## Notes for Deployment

## Screenshots (if appropriate)

### Before
![image](https://user-images.githubusercontent.com/10214785/148673708-d0054523-ecbb-4e88-bd3a-9a85c2143781.png)
![image](https://user-images.githubusercontent.com/10214785/148673721-9aec2ac3-3b8c-4922-a96d-92eb9425aaa0.png)

### After 
![image](https://user-images.githubusercontent.com/10214785/148673729-5babfdbf-5a5c-40fb-8dfd-1042df2aa83a.png)
![image](https://user-images.githubusercontent.com/10214785/148673740-18e15eb6-0b1c-44ce-a713-3d727615d805.png)
![image](https://user-images.githubusercontent.com/10214785/148673752-42f40bcc-b3a1-44b0-bb62-0ab5f6ec0503.png)

## Tests and linting

I haven't run tests or linting because it's late and I'm going to bed but inshallah they pass :crossed_fingers: 

 - [x] I have rebased my changes on `main`

 - [ ] `just lint` passes

 - [ ] `just test` passes
