### PR TITLE
Add extra info for upload

### DIFF
--- a/OpenOversight/app/templates/submit_image.html
+++ b/OpenOversight/app/templates/submit_image.html
@@ -42,7 +42,11 @@
 
     <form id="my-cop-dropzone" action="/upload/department/1" class='dropzone'>
     </form>
-    <p>Drag photographs from your computer directly into the box above or click the box to launch a finder window. If you are on mobile, you can click the box above to select pictures from your photo library or camera roll.</p>
+    <p>
+      Drag photographs from your computer directly into the box above or click the box to launch a finder window.
+      If you are on mobile, you can click the box above to select pictures from your photo library or camera roll.
+      An image is successfully uploaded when you see a check mark over it.
+    </p>
 
     <script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/dropzone.js') }}"></script>


### PR DESCRIPTION
## Description of Changes

We got word from a user that they weren't sure when an upload was complete, since there is no submit button. This PR adds a line of text to the upload page to inform the user when uploads are complete.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [ ] `just lint` passes

 - [ ] `just test` passes
