### PR TITLE
Sort incidents by date descending on officer page

### DIFF
--- a/OpenOversight/app/templates/partials/officer_incidents.html
+++ b/OpenOversight/app/templates/partials/officer_incidents.html
@@ -1,7 +1,7 @@
 <h3>Incidents</h3>
 {% if officer.incidents %}
     <ul class="list-group">
-    {% for incident in officer.incidents %}
+    {% for incident in officer.incidents | sort(attribute='date') | reverse %}
         <li class="list-group-item">
         <h4>
             <a href="{{ url_for('main.incident_api', obj_id=incident.id)}}">


### PR DESCRIPTION
## Description of Changes

This PR changes the incident ordering on the officer page so the most recent incident appears first.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [ ] `just lint` passes

 - [ ] `just test` passes
