### PR TITLE
Change link title name

### DIFF
--- a/data-munging/opa_incidents.py
+++ b/data-munging/opa_incidents.py
@@ -196,7 +196,7 @@ def match_links(incidents: pd.DataFrame, opas: Dict[str, str]) -> pd.DataFrame:
     matched_opas = matched_opas[["url", "report_number", "id", "officer_ids"]]
     # Rename columns
     matched_opas.columns = ["url", "title", "incident_ids", "officer_ids"]
-    matched_opas.loc[:, "title"] = "OPA Case " + matched_opas["title"]
+    matched_opas.loc[:, "title"] = "Closed Case Summary " + matched_opas["title"]
     # Add the common fields
     matched_opas["link_type"] = "Link"
     matched_opas["author"] = "Seattle Office of Police Accountability"


### PR DESCRIPTION
## Description of Changes

Previously, links were prefixed with `OPA Case <incident title>`. Since incidents were prefixed with `OPA Case <case#>`, this meant links were `OPA Case OPA Case <case#>`. I've already changed the underlying data, but this changes future uploads to ensure that the links produced are prefixed with `Closed Case Summary` instead.

## Notes for Deployment

None

## Screenshots (if appropriate)

## Tests and linting

 - [ ] I have rebased my changes on `main`

 - [ ] `just lint` passes

 - [ ] `just test` passes
