### PR TITLE
Add incident description cutoff script to incident list

### DIFF
--- a/OpenOversight/app/templates/incident_list.html
+++ b/OpenOversight/app/templates/incident_list.html
@@ -38,3 +38,6 @@
 	  </a>
 	{% endif %}
 {% endblock list %}
+{% block js_footer %}
+  <script src="{{ url_for('static', filename='js/incidentDescription.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Description of Changes

As part of #110, I erroneously removed the incident description Javascript from the incident list page. It was working fine on the officer page, but it wasn't being imported into the incident list page at all. This PR fixes that!

## Notes for Deployment

Just needs a deploy!

## Screenshots (if appropriate)

## Tests and linting

 - [ ] I have rebased my changes on `main`

 - [ ] `just lint` passes

 - [ ] `just test` passes
