### PR TITLE
Provide better metadata for incidents page

### DIFF
--- a/OpenOversight/app/templates/incident_detail.html
+++ b/OpenOversight/app/templates/incident_detail.html
@@ -2,11 +2,7 @@
 {% set incident = obj %}
 {% block title %}{{ incident.department.name }} incident{% if incident.report_number %} {{incident.report_number}}{% endif %} - OpenOversight{% endblock %}
 {% block meta %}
-  {% if incident.description != None %}
-    <meta name="description" content="{{ incident.description }}">
-  {% else %}
-    <meta name="description" content="View details for {{ incident.department.name }} incident{% if incident.report_number %} {{incident.report_number}}{% endif %}.">
-  {% endif %}
+  <meta name="description" content="View details for {{ incident.department.name }} incident{% if incident.report_number %} {{incident.report_number}}{% endif %}.">
   <!-- Google Breadcrumb https://developers.google.com/search/docs/data-types/breadcrumb -->
   <script type="application/ld+json">
 	{


### PR DESCRIPTION
## Description of Changes
Fixes #113. Use the default incident description instead of `incident.description`

Change also upgrades black version to fix GitHub Action pre-commit test:
https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click

Change also upgrades Flask and Flask-Login versions to fix `safe_str_cmp` missing function error:
https://stackoverflow.com/questions/71652965/importerror-cannot-import-name-safe-str-cmp-from-werkzeug-security

## Notes for Deployment
None!

## Screenshots (if appropriate)
Not a screenshot but here's the description tag from a test incident:
```
  <meta name="description" content="View details for Seattle Police Department incident 2000OPA-0001.">
```

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
