### PR TITLE
Add incident search

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -597,3 +597,11 @@ class BrowseForm(Form):
         validators=[AnyOf(allowed_values(AGE_CHOICES))],
     )
     submit = SubmitField(label="Submit")
+
+
+class IncidentListForm(Form):
+    department_id = HiddenField("Department Id")
+    report_number = StringField("Report Number")
+    occurred_before = DateField("Occurred Before")
+    occurred_after = DateField("Occurred After")
+    submit = SubmitField(label="Submit")

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1391,7 +1391,9 @@ class IncidentApi(ModelView):
 
         if report_number := request.args.get("report_number"):
             form.report_number.data = report_number
-            incidents = incidents.filter_by(report_number=report_number)
+            incidents = incidents.filter(
+                Incident.report_number.contains(report_number.strip())
+            )
 
         if occurred_before := request.args.get("occurred_before"):
             before_date = datetime.datetime.strptime(occurred_before, "%Y-%m-%d").date()

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import re
 import sys
@@ -79,6 +80,7 @@ from .forms import (
     FindOfficerForm,
     FindOfficerIDForm,
     IncidentForm,
+    IncidentListForm,
     OfficerLinkForm,
     SalaryForm,
     TextForm,
@@ -1368,26 +1370,70 @@ class IncidentApi(ModelView):
     department_check = True
 
     def get(self, obj_id):
+        if obj_id:
+            # Single-item view
+            return super(IncidentApi, self).get(obj_id)
+
+        # List view
         if request.args.get("page"):
             page = int(request.args.get("page"))
         else:
             page = 1
-        if request.args.get("department_id"):
-            department_id = request.args.get("department_id")
+
+        form = IncidentListForm()
+        incidents = self.model.query
+
+        dept = None
+        if department_id := request.args.get("department_id"):
             dept = Department.query.get_or_404(department_id)
-            obj = (
-                self.model.query.filter_by(department_id=department_id)
-                .order_by(getattr(self.model, self.order_by).desc())
-                .paginate(page, self.per_page, False)
-            )
-            return render_template(
-                "{}_list.html".format(self.model_name),
-                objects=obj,
-                url="main.{}_api".format(self.model_name),
-                department=dept,
-            )
-        else:
-            return super(IncidentApi, self).get(obj_id)
+            form.department_id.data = department_id
+            incidents = incidents.filter_by(department_id=department_id)
+
+        if report_number := request.args.get("report_number"):
+            form.report_number.data = report_number
+            incidents = incidents.filter_by(report_number=report_number)
+
+        if occurred_before := request.args.get("occurred_before"):
+            before_date = datetime.datetime.strptime(occurred_before, "%Y-%m-%d").date()
+            form.occurred_before.data = before_date
+            incidents = incidents.filter(self.model.date < before_date)
+
+        if occurred_after := request.args.get("occurred_after"):
+            after_date = datetime.datetime.strptime(occurred_after, "%Y-%m-%d").date()
+            form.occurred_after.data = after_date
+            incidents = incidents.filter(self.model.date > after_date)
+
+        incidents = incidents.order_by(
+            getattr(self.model, self.order_by).desc()
+        ).paginate(page, self.per_page, False)
+
+        url = "main.{}_api".format(self.model_name)
+        next_url = url_for(
+            url,
+            page=incidents.next_num,
+            department_id=department_id,
+            report_number=report_number,
+            occurred_after=occurred_after,
+            occurred_before=occurred_before,
+        )
+        prev_url = url_for(
+            url,
+            page=incidents.prev_num,
+            department_id=department_id,
+            report_number=report_number,
+            occurred_after=occurred_after,
+            occurred_before=occurred_before,
+        )
+
+        return render_template(
+            "{}_list.html".format(self.model_name),
+            form=form,
+            incidents=incidents,
+            url=url,
+            next_url=next_url,
+            prev_url=prev_url,
+            department=dept,
+        )
 
     def get_new_form(self):
         form = self.form()

--- a/OpenOversight/app/templates/incident_list.html
+++ b/OpenOversight/app/templates/incident_list.html
@@ -1,43 +1,79 @@
-{% extends "list.html" %}
+{% extends "base.html" %}
+{% import "bootstrap/wtf.html" as wtf %}
 {% block title %}View incidents - OpenOversight{% endblock %}
 {% block meta %}
-	{% if objects.items|length > 0 %}
-		<meta name="description" content="View all incidents for {{ department.name if department else 'OpenOversight' }}.">
-	{% else %}
-		<meta name="description" content="No incidents found.">
-	{% endif %}
+  {% if incidents.items|length > 0 %}
+    <meta name="description" content="View all incidents for {{ department.name if department else 'OpenOversight' }}.">
+  {% else %}
+    <meta name="description" content="No incidents found.">
+  {% endif %}
 {% endblock %}
-{% block list %}
-	<h1>Incidents</h1>
-	{% if department %}
-		<h2><small>{{ department.name }}</small></h2>
-	{% endif %}
-	<ul class="list-group">
-		{% if objects.items %}
-		  {% for incident in objects.items %}
-		  	<li class="list-group-item">
-		  		<h3>
-		  				<a href="{{ url_for('main.incident_api', obj_id=incident.id)}}">
-		  				Incident
-              {% if incident.report_number %}
-                {{ incident.report_number }}
-              {% endif %}
-		  			</a>
-		  		</h3>
-		    	{% include 'partials/incident_fields.html' %}
-		    </li>
-		  {% endfor %}
-		{% else %}
-			<p>There are no incidents.</p>
-		{% endif %}
-	</ul>
-	{% if current_user.is_administrator or current_user.is_area_coordinator %}
-		<a href="{{ url_for('main.incident_api')+ 'new' }}" class="btn btn-primary" role="button">
-	      <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
-	      Add New Incident
-	  </a>
-	{% endif %}
-{% endblock list %}
+{% block content %}
+  <div class="container" role="main">
+    <h1>Incidents</h1>
+    {% if department %}
+      <h2><small>{{ department.name }}</small></h2>
+    {% endif %}
+    <div class="row">
+      <div class="filter-sidebar col-sm-3">
+        <h3 class="sidebar-title">Filter incidents</h3>
+        <form class="form" method="get" role="form">
+          {% if department %}
+          <div class="hidden">
+          {{ wtf.form_field(form.department_id) }}
+          </div>
+          {% endif %}
+          <div class="panel">
+          {{ wtf.form_field(form.report_number) }}
+          </div>
+          <div class="panel">
+          {{ wtf.form_field(form.occurred_before) }}
+          </div>
+          <div class="panel">
+          {{ wtf.form_field(form.occurred_after) }}
+          </div>
+          <div class="panel">
+          {{ wtf.form_field(form.submit, id="submit", button_map={'submit':'primary'}) }}
+          </div>
+        </form>
+      </div>
+      <div class="search-results col-sm-9">
+        {% with paginate=incidents, location='top' %}
+          {% include "partials/paginate_nav.html" %}
+        {% endwith %}
+
+        <ul class="list-group">
+          {% if incidents.items %}
+            {% for incident in incidents.items %}
+              <li class="list-group-item">
+                <h3>
+                  <a href="{{ url_for('main.incident_api', obj_id=incident.id)}}">
+                    Incident
+                  {% if incident.report_number %}
+                    {{ incident.report_number }}
+                  {% endif %}
+                  </a>
+                </h3>
+                {% include 'partials/incident_fields.html' %}
+              </li>
+            {% endfor %}
+          {% else %}
+            <p>There are no incidents.</p>
+          {% endif %}
+        </ul>
+        {% if current_user.is_administrator or current_user.is_area_coordinator %}
+          <a href="{{ url_for('main.incident_api')+ 'new' }}" class="btn btn-primary" role="button">
+              <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+              Add New Incident
+          </a>
+        {% endif %}
+      {% with paginate=incidents, location='bottom' %}
+        {% include "partials/paginate_nav.html" %}
+      {% endwith %}
+      </div>
+    </div>
+  </div>
+{% endblock content %}
 {% block js_footer %}
   <script src="{{ url_for('static', filename='js/incidentDescription.js') }}"></script>
 {% endblock %}

--- a/OpenOversight/tests/routes/test_incidents.py
+++ b/OpenOversight/tests/routes/test_incidents.py
@@ -695,13 +695,15 @@ def test_form_with_officer_id_prepopulates(mockdata, client, session):
     "params,included_report_nums,excluded_report_nums",
     [
         ({"department_id": "1"}, ["42"], ["38", "39"]),
-        ({"report_number": "38"}, ["38"], ["42", "39"]),
         ({"occurred_before": "2017-12-12"}, ["38", "42"], ["39"]),
         (
             {"occurred_after": "2017-12-10", "occurred_before": "2019-01-01"},
             ["38"],
             ["39", "42"],
         ),
+        ({"report_number": "38"}, ["38"], ["42", "39"]),  # Base case
+        ({"report_number": "3"}, ["38", "39"], ["42"]),  # Test inclusive match
+        ({"report_number": "38 "}, ["38"], ["42", "39"]),  # Test trim
     ],
 )
 def test_users_can_search_incidents(

--- a/OpenOversight/tests/routes/test_incidents.py
+++ b/OpenOversight/tests/routes/test_incidents.py
@@ -689,3 +689,29 @@ def test_form_with_officer_id_prepopulates(mockdata, client, session):
             url_for("main.incident_api") + "new?officer_id={}".format(officer_id)
         )
         assert officer_id in rv.data.decode("utf-8")
+
+
+@pytest.mark.parametrize(
+    "params,included_report_nums,excluded_report_nums",
+    [
+        ({"department_id": "1"}, ["42"], ["38", "39"]),
+        ({"report_number": "38"}, ["38"], ["42", "39"]),
+        ({"occurred_before": "2017-12-12"}, ["38", "42"], ["39"]),
+        (
+            {"occurred_after": "2017-12-10", "occurred_before": "2019-01-01"},
+            ["38"],
+            ["39", "42"],
+        ),
+    ],
+)
+def test_users_can_search_incidents(
+    params, included_report_nums, excluded_report_nums, mockdata, client, session
+):
+    with current_app.test_request_context():
+        rv = client.get(url_for("main.incident_api", **params))
+
+        for report_num in included_report_nums:
+            assert "<td>{}</td>".format(report_num) in rv.data.decode("utf-8")
+
+        for report_num in excluded_report_nums:
+            assert "<td>{}</td>".format(report_num) not in rv.data.decode("utf-8")


### PR DESCRIPTION
## Description of Changes
Fixes #104 because you can look up an incident by case number and see the officers involved (?)

Add incident search by report number and occurred date (and department implicitly). I'm not sure if there are any other fields we normally populate that would be useful to filter by. 

(I'm temporarily setting the target branch to #121 to avoid duplicating dependency fixes)

## Notes for Deployment
None!

## Screenshots (if appropriate)
![oo_incident_search](https://user-images.githubusercontent.com/66500457/168462616-cd04baa2-93ac-474a-b6f8-ce22134278a7.png)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
