### PR TITLE
Fix sqlite decimal warning

### DIFF
--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -4,6 +4,7 @@ import csv
 import sys
 from builtins import input
 from datetime import date, datetime
+from decimal import Decimal
 from getpass import getpass
 from typing import Dict, List
 
@@ -396,21 +397,18 @@ def process_salary(row, officer, compare=False):
             # Get existing salaries for officer and compare to row data
             salaries = Salary.query.filter_by(officer_id=officer.id).all()
             for salary in salaries:
-                from decimal import Decimal
-
                 print(vars(salary))
                 print(row)
                 if (
-                    Decimal("%.2f" % salary.salary)
-                    == Decimal("%.2f" % float(row["salary"]))
+                    round(salary.salary, 2) == round(Decimal(row["salary"]), 2)
                     and salary.year == int(row["salary_year"])
                     and salary.is_fiscal_year == is_fiscal_year
                     and (
                         (
                             salary.overtime_pay
                             and "overtime_pay" in row
-                            and Decimal("%.2f" % salary.overtime_pay)
-                            == Decimal("%.2f" % float(row["overtime_pay"]))
+                            and round(salary.overtime_pay, 2)
+                            == round(Decimal(row["overtime_pay"]), 2)
                         )
                         or (
                             not salary.overtime_pay
@@ -425,12 +423,12 @@ def process_salary(row, officer, compare=False):
             # create new salary
             salary = Salary(
                 officer_id=officer.id,
-                salary=float(row["salary"]),
+                salary=round(Decimal(row["salary"]), 2),
                 year=int(row["salary_year"]),
                 is_fiscal_year=is_fiscal_year,
             )
             if "overtime_pay" in row and row["overtime_pay"]:
-                salary.overtime_pay = float(row["overtime_pay"])
+                salary.overtime_pay = round(Decimal(row["overtime_pay"]), 2)
             db.session.add(salary)
             db.session.flush()
 

--- a/OpenOversight/app/model_imports.py
+++ b/OpenOversight/app/model_imports.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, Union
 
 import dateutil.parser
@@ -50,9 +51,9 @@ def parse_int(value: Optional[Union[str, int]]) -> Optional[int]:
     return None
 
 
-def parse_float(value: Optional[Union[str, float]]) -> Optional[float]:
-    if value == 0.0 or value:
-        return float(value)
+def parse_decimal(value: Optional[Union[str, Decimal]]) -> Optional[Decimal]:
+    if value == Decimal(0) or value:
+        return Decimal(value)
     return None
 
 
@@ -162,8 +163,8 @@ def update_assignment_from_dict(
 def create_salary_from_dict(data: Dict[str, Any], force_id: bool = False) -> Salary:
     salary = Salary(
         officer_id=int(data["officer_id"]),
-        salary=float(data["salary"]),
-        overtime_pay=parse_float(data.get("overtime_pay")),
+        salary=Decimal(data["salary"]),
+        overtime_pay=parse_decimal(data.get("overtime_pay")),
         year=int(data["year"]),
         is_fiscal_year=parse_bool(data.get("is_fiscal_year")),
     )

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -6,6 +6,7 @@ import sys
 import threading
 import time
 import uuid
+from decimal import Decimal
 from io import BytesIO
 from pathlib import Path
 from typing import List
@@ -111,7 +112,7 @@ def pick_uid():
 
 
 def pick_salary():
-    return random.randint(100, 100000000) / 100
+    return Decimal(random.randint(100, 100000000)) / 100
 
 
 def generate_officer():

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -4,6 +4,7 @@ import csv
 import json
 import random
 from datetime import date, datetime
+from decimal import Decimal
 from io import BytesIO
 
 import pytest
@@ -1894,7 +1895,7 @@ def test_admin_can_add_salary(mockdata, client, session):
         login_admin(client)
 
         form = SalaryForm(
-            salary=123456.78, overtime_pay=666.66, year=2019, is_fiscal_year=False
+            salary="123456.78", overtime_pay="666.66", year=2019, is_fiscal_year=False
         )
 
         rv = client.post(
@@ -1906,7 +1907,9 @@ def test_admin_can_add_salary(mockdata, client, session):
         assert "Added new salary" in rv.data.decode("utf-8")
         assert "<td>$123,456.78</td>" in rv.data.decode("utf-8")
 
-        officer = Officer.query.filter(Officer.salaries.any(salary=123456.78)).first()
+        officer = Officer.query.filter(
+            Officer.salaries.any(salary=Decimal("123456.78"))
+        ).first()
         assert officer is not None
 
 
@@ -1915,7 +1918,7 @@ def test_ac_can_add_salary_in_their_dept(mockdata, client, session):
         login_ac(client)
 
         form = SalaryForm(
-            salary=123456.78, overtime_pay=666.66, year=2019, is_fiscal_year=False
+            salary="123456.78", overtime_pay="666.66", year=2019, is_fiscal_year=False
         )
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
 
@@ -1928,7 +1931,9 @@ def test_ac_can_add_salary_in_their_dept(mockdata, client, session):
         assert "Added new salary" in rv.data.decode("utf-8")
         assert "<td>$123,456.78</td>" in rv.data.decode("utf-8")
 
-        officer = Officer.query.filter(Officer.salaries.any(salary=123456.78)).first()
+        officer = Officer.query.filter(
+            Officer.salaries.any(salary=Decimal("123456.78"))
+        ).first()
         assert officer is not None
 
 
@@ -1937,7 +1942,7 @@ def test_ac_cannot_add_non_dept_salary(mockdata, client, session):
         login_ac(client)
 
         form = SalaryForm(
-            salary=123456.78, overtime_pay=666.66, year=2019, is_fiscal_year=False
+            salary="123456.78", overtime_pay="666.66", year=2019, is_fiscal_year=False
         )
         officer = Officer.query.except_(
             Officer.query.filter_by(department_id=AC_DEPT)
@@ -1960,7 +1965,7 @@ def test_admin_can_edit_salary(mockdata, client, session):
         Salary.query.filter_by(officer_id=1).delete()
 
         form = SalaryForm(
-            salary=123456.78, overtime_pay=666.66, year=2019, is_fiscal_year=False
+            salary="123456.78", overtime_pay="666.66", year=2019, is_fiscal_year=False
         )
 
         rv = client.post(
@@ -1972,7 +1977,7 @@ def test_admin_can_edit_salary(mockdata, client, session):
         assert "Added new salary" in rv.data.decode("utf-8")
         assert "<td>$123,456.78</td>" in rv.data.decode("utf-8")
 
-        form = SalaryForm(salary=150000)
+        form = SalaryForm(salary="150000")
         officer = Officer.query.filter_by(id=1).one()
 
         rv = client.post(
@@ -1990,7 +1995,7 @@ def test_admin_can_edit_salary(mockdata, client, session):
         assert "<td>$150,000.00</td>" in rv.data.decode("utf-8")
 
         officer = Officer.query.filter_by(id=1).one()
-        assert officer.salaries[0].salary == 150000
+        assert officer.salaries[0].salary == Decimal(150000)
 
 
 def test_ac_can_edit_salary_in_their_dept(mockdata, client, session):
@@ -2003,7 +2008,7 @@ def test_ac_can_edit_salary_in_their_dept(mockdata, client, session):
         Salary.query.filter_by(officer_id=officer_id).delete()
 
         form = SalaryForm(
-            salary=123456.78, overtime_pay=666.66, year=2019, is_fiscal_year=False
+            salary="123456.78", overtime_pay="666.66", year=2019, is_fiscal_year=False
         )
 
         rv = client.post(
@@ -2015,7 +2020,7 @@ def test_ac_can_edit_salary_in_their_dept(mockdata, client, session):
         assert "Added new salary" in rv.data.decode("utf-8")
         assert "<td>$123,456.78</td>" in rv.data.decode("utf-8")
 
-        form = SalaryForm(salary=150000)
+        form = SalaryForm(salary="150000")
         officer = Officer.query.filter_by(id=officer_id).one()
 
         rv = client.post(
@@ -2033,7 +2038,7 @@ def test_ac_can_edit_salary_in_their_dept(mockdata, client, session):
         assert "<td>$150,000.00</td>" in rv.data.decode("utf-8")
 
         officer = Officer.query.filter_by(id=officer_id).one()
-        assert officer.salaries[0].salary == 150000
+        assert officer.salaries[0].salary == Decimal(150000)
 
 
 def test_ac_cannot_edit_non_dept_salary(mockdata, client, session):
@@ -2047,7 +2052,7 @@ def test_ac_cannot_edit_non_dept_salary(mockdata, client, session):
         Salary.query.filter_by(officer_id=officer_id).delete()
 
         form = SalaryForm(
-            salary=123456.78, overtime_pay=666.66, year=2019, is_fiscal_year=False
+            salary="123456.78", overtime_pay="666.66", year=2019, is_fiscal_year=False
         )
 
         login_admin(client)
@@ -2061,7 +2066,7 @@ def test_ac_cannot_edit_non_dept_salary(mockdata, client, session):
         assert "<td>$123,456.78</td>" in rv.data.decode("utf-8")
 
         login_ac(client)
-        form = SalaryForm(salary=150000)
+        form = SalaryForm(salary="150000")
         officer = Officer.query.filter_by(id=officer_id).one()
 
         rv = client.post(
@@ -2078,7 +2083,7 @@ def test_ac_cannot_edit_non_dept_salary(mockdata, client, session):
         assert rv.status_code == 403
 
         officer = Officer.query.filter_by(id=officer_id).one()
-        assert float(officer.salaries[0].salary) == 123456.78
+        assert officer.salaries[0].salary == Decimal("123456.78")
 
 
 def test_get_department_ranks_with_specific_department_id(mockdata, client, session):

--- a/OpenOversight/tests/test_commands.py
+++ b/OpenOversight/tests/test_commands.py
@@ -4,6 +4,7 @@ import operator
 import os
 import traceback
 import uuid
+from decimal import Decimal
 
 import pandas as pd
 import pytest
@@ -423,7 +424,9 @@ def test_csv_new_salary(csvfile):
     officer = Officer.query.filter_by(id=officer_id).one()
     assert len(list(officer.salaries)) == 2
     for salary in officer.salaries:
-        assert float(salary.salary) == 123456.78 or float(salary.salary) == 150000.00
+        assert salary.salary == Decimal("123456.78") or salary.salary == Decimal(
+            "150000.00"
+        )
 
 
 def test_bulk_add_officers__success(session, department_with_ranks, csv_path):

--- a/justfile
+++ b/justfile
@@ -76,6 +76,10 @@ import +args:
 lint:
     pre-commit run --all-files
 
+# Run Flask-Migrate tasks in the web container
+db +migrateargs:
+    just run --no-deps web flask db {{ migrateargs }}
+
 # Run unit tests in the web container
 test *pytestargs:
     just run --no-deps web pytest -n auto -m "not acceptance" {{ pytestargs }}


### PR DESCRIPTION
## Description of Changes
Fixes #126.

Since we use sqlite in our unit tests and sqlite doesn't have a decimal type, sqlalchemy shows a floating-point warning when we work with salaries during testing.

This change fixes the warnings by adding a TypeDecorator to convert currency values to integers by multiplying by 100 when storing values and dividing by 100 when retrieving them. It also changes parts of the salary import code to use Decimal instead of float.

## Notes for Deployment
Might be a good idea to test the csv imports a little more before deploying?

## Screenshots (if appropriate)
N/A

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
