### PR TITLE
Pin werkzeug to compliant version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,9 @@ python-dateutil==2.8.2
 python-dotenv==0.20.0
 SQLAlchemy==1.4.21
 us==1.0
+# FIXME
+# Werkzeug 2.1.3 does not have parse_rule available, remove this when
+# other dependencies can play nice
+# https://stackoverflow.com/q/73105877/3277713
+werkzeug==2.1.2
 WTForms<3.0.0


### PR DESCRIPTION
## Description of Changes
This PR fixes an issue we're seeing on a few of the other dependabot PRs, which is causing failures unrelated to the changeset. Werkzeug appears to have removed access to a function (`parse_rule`) which is required by Flask or some other dependency. This pins the `werkzeug` version to 2.1.2 until we can upgrade Flask and/or address the issue.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
