### PR TITLE
Fix Werkzeug import error

### DIFF
--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -13,7 +13,7 @@ from typing import List, Optional
 
 import pytest
 from faker import Faker
-from flask import current_app
+from flask import current_app, g
 from PIL import Image as Pimage
 from selenium import webdriver
 from xvfbwrapper import Xvfb
@@ -235,6 +235,12 @@ def session(db, request):
         transaction.rollback()
         connection.close()
         session.remove()
+
+        # Since Flask-Login now records the logged in user on the Flask `g` object and we persist the app context
+        # (in the app fixture) for the entire testing session, we need to reset this value manually.
+        #
+        # Relevant PR: https://github.com/maxcountryman/flask-login/pull/691
+        g.pop("_login_user", None)
 
     request.addfinalizer(teardown)
     return session

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Fabric3==1.14.post1
 Flask==2.1.2
 Flask-Bootstrap==3.3.7.1
 Flask-Limiter==1.4
-Flask-Login==0.6.1
+Flask-Login==0.6.2
 Flask-Mail==0.9.1
 Flask-Migrate==3.0.1
 Flask-Sitemap==0.4.0


### PR DESCRIPTION
## Description of Changes
Fix Werkzeug import error by upgrading Flask-Login to 0.6.2
https://stackoverflow.com/questions/73105877/importerror-cannot-import-name-parse-rule-from-werkzeug-routing

```
Creating openoversight_web_run    ... done
Traceback (most recent call last):
  File "/usr/src/app/OpenOversight/../create_db.py", line 2, in <module>
    from OpenOversight.app import create_app
  File "/usr/src/app/OpenOversight/app/__init__.py", line 10, in <module>
    from flask_login import LoginManager
  File "/usr/local/lib/python3.9/site-packages/flask_login/__init__.py", line 12, in <module>
    from .login_manager import LoginManager
  File "/usr/local/lib/python3.9/site-packages/flask_login/login_manager.py", line 35, in <module>
    from .utils import _create_identifier
  File "/usr/local/lib/python3.9/site-packages/flask_login/utils.py", line 14, in <module>
    from werkzeug.routing import parse_rule
ImportError: cannot import name 'parse_rule' from 'werkzeug.routing' (/usr/local/lib/python3.9/site-packages/werkzeug/routing/__init__.py)
ERROR: 1
error: Recipe `fresh-start` failed on line 55 with exit code 1
```

## Notes for Deployment
None!

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
