### PR TITLE
Add option to search only by current job

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -79,6 +79,7 @@ class HumintContribution(Form):
 
 
 class FindOfficerForm(Form):
+    # Any fields added to this form should generally also be added to BrowseForm
     name = StringField(
         "name", default="", validators=[Regexp(r"\w*"), Length(max=50), Optional()]
     )
@@ -97,6 +98,7 @@ class FindOfficerForm(Form):
         get_label="name",
     )
     unit = StringField("unit", default="Not Sure", validators=[Optional()])
+    current_job = BooleanField("current_job", default=False, validators=[Optional()])
     rank = StringField(
         "rank", default="Not Sure", validators=[Optional()]
     )  # Gets rewritten by Javascript
@@ -557,6 +559,7 @@ class IncidentForm(DateFieldForm):
 
 
 class BrowseForm(Form):
+    # Any fields added to this form should generally also be added to FindOfficerForm
     rank = QuerySelectField(
         "rank",
         validators=[Optional()],
@@ -569,6 +572,7 @@ class BrowseForm(Form):
         get_label="descrip",
         get_pk=lambda unit: unit.descrip,
     )  # query set in view function
+    current_job = BooleanField("current_job", default=False, validators=[Optional()])
     name = StringField("Last name")
     badge = StringField("Badge number")
     unique_internal_identifier = StringField("Unique ID")

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -625,6 +625,7 @@ def list_officer(
     badge=None,
     unique_internal_identifier=None,
     unit=None,
+    current_job=None,
 ):
     jsloads = ["js/select2.min.js", "js/list_officer.js"]
 
@@ -644,6 +645,7 @@ def list_officer(
     form_data["first_name"] = first_name
     form_data["badge"] = badge
     form_data["unit"] = unit or []
+    form_data["current_job"] = current_job
     form_data["unique_internal_identifier"] = unique_internal_identifier
 
     OFFICERS_PER_PAGE = int(current_app.config["OFFICERS_PER_PAGE"])
@@ -701,6 +703,8 @@ def list_officer(
         rank in rank_choices for rank in ranks
     ):
         form_data["rank"] = ranks
+    if current_job_arg := request.args.get("current_job"):
+        form_data["current_job"] = current_job_arg
 
     officers = filter_by_form(form_data, Officer.query, department_id).filter(
         Officer.department_id == department_id
@@ -738,6 +742,7 @@ def list_officer(
         badge=form_data["badge"],
         unique_internal_identifier=form_data["unique_internal_identifier"],
         unit=form_data["unit"],
+        current_job=form_data["current_job"],
     )
     prev_url = url_for(
         "main.list_officer",
@@ -753,6 +758,7 @@ def list_officer(
         badge=form_data["badge"],
         unique_internal_identifier=form_data["unique_internal_identifier"],
         unit=form_data["unit"],
+        current_job=form_data["current_job"],
     )
 
     return render_template(

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -485,7 +485,7 @@ tr:hover .row-actions {
 }
 
 .filter-sidebar .panel-body-long {
-    max-height: 20vh;
+    max-height: 25vh;
     overflow-y: auto;
 }
 

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -79,30 +79,44 @@
           </div>
         </div>
         <div class="panel">
-          <div class="panel-heading" data-toggle="collapse" data-target="#filter-rank">
-            <h3 class="panel-title accordion-toggle">Rank</h3>
+          <div class="panel-heading" data-toggle="collapse" data-target="#filter-job">
+            <h3 class="panel-title accordion-toggle">Job</h3>
           </div>
-          <div class="collapse {{ form_data | field_in_query("rank") }}" id="filter-rank">
+          <div class="collapse {{ form_data | field_in_query("rank") }} {{ form_data | field_in_query("unit") }} {{ form_data | field_in_query("current_job") }}" id="filter-job">
             <div class="panel-body panel-body-long">
-              <select name="rank" class="select2-multi-search" multiple="multiple">
-                {% for choice in choices['rank'] %}
-                <option value="{{ choice[0] }}"{% if choice[0] in form_data['rank'] %} selected="selected" {% endif %}>{{ choice[1] }}</option>
-                {% endfor %}
-              </select>
-            </div>
-          </div>
-        </div>
-        <div class="panel">
-          <div class="panel-heading" data-toggle="collapse" data-target="#filter-unit">
-            <h3 class="panel-title accordion-toggle">Unit</h3>
-          </div>
-          <div class="collapse {{ form_data | field_in_query("unit") }}" id="filter-unit">
-            <div class="panel-body panel-body-long">
-              <select name="unit" class="select2-multi-search" multiple="multiple">
-                {% for choice in choices['unit'] %}
-                <option value="{{ choice[0] }}"{% if choice[0] in form_data['unit'] %} selected="selected" {% endif %}>{{choice[1]}}</option>
-                {% endfor %}
-              </select>
+              <div class="form-row">
+                <div class="form-group">
+                  <label for="current_job">
+                    <input id="current_job" name="current_job" type="checkbox" {% if form_data.get("current_job") %}checked{% endif %}>
+                      Currently employed
+                  </label>
+                  <span>(in this rank and/or unit, if specified)</span>
+                </div>
+              </div>
+              <br />
+
+              <div class="form-row">
+                <div class="form-group">
+                  <label for="rank">Rank</label>
+                  <select id="rank" name="rank" class="select2-multi-search" multiple="multiple">
+                    {% for choice in choices['rank'] %}
+                    <option value="{{ choice[0] }}"{% if choice[0] in form_data['rank'] %} selected="selected" {% endif %}>{{ choice[1] }}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+              </div>
+              <br />
+
+              <div class="form-row">
+                <div class="form-group">
+                  <label for="unit">Unit</label>
+                  <select id="unit" name="unit" class="select2-multi-search" multiple="multiple">
+                    {% for choice in choices['unit'] %}
+                    <option value="{{ choice[0] }}"{% if choice[0] in form_data['unit'] %} selected="selected" {% endif %}>{{choice[1]}}</option>
+                    {% endfor %}
+                  </select>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -386,6 +386,9 @@ def filter_by_form(form_data, officer_query, department_id=None):
 
         if job_ids:
             officer_query = officer_query.filter(Assignment.job_id.in_(job_ids))
+
+        if form_data.get("current_job"):
+            officer_query = officer_query.filter(Assignment.resign_date.is_(None))
     officer_query = officer_query.options(selectinload(Officer.assignments_lazy))
 
     return officer_query

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -1690,6 +1690,7 @@ def test_browse_filtering_allows_good(client, mockdata, session):
             rank=job.job_title,
             min_age=datetime.now().year - 1991,
             max_age=datetime.now().year - 1989,
+            current_job=True,
         )
 
         data = process_form_data(form.data)


### PR DESCRIPTION
## Description of Changes
Fixes #149 and #153.

* Add option to search only by current job. I'm assuming that an assignment with no `retire_date` indicates that it is the officer's current assignment (@AetherUnbound would you mind double-checking this?)
* Combined Unit/Rank into a "Job" panel in the Browse Officer screen

## Notes for Deployment
(This PR currently includes the werkzeug fix in https://github.com/OrcaCollective/OpenOversight/pull/167 so it builds)

## Screenshots (if appropriate)
**Before**: (All generated assignments have no `retire_date`, so they appear to be current)
![1](https://user-images.githubusercontent.com/66500457/184466205-ebe22e9a-d698-4dd1-94fb-18f18d8a789f.png)

**Run query to set `retire_date`**:
```
update assignments set resign_date = now() where officer_id = (select id from officers where last_name = 'Abbotson');
```

**After**: (Officer doesn't have a current assignment and so doesn't show up)
![2](https://user-images.githubusercontent.com/66500457/184466363-eeb2f181-9240-4287-9690-ed8fab22abb7.png)

**Uncheck "Currently employed"**:
![3](https://user-images.githubusercontent.com/66500457/184466600-e4a4e466-d8d2-4f0b-aa2a-c454457c8754.png)


## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
