### PR TITLE
Fix functional tests

### DIFF
--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -673,14 +673,17 @@ def client(app, request):
     return client
 
 
-@pytest.fixture
-def browser(app, request):
+@pytest.fixture(scope="session")
+def server(app, request):
     # start server without werkzeug auto-refresh
     # https://stackoverflow.com/questions/38087283/
     threading.Thread(target=app.run, daemon=True, kwargs={"debug": False}).start()
     # give the server a few seconds to ensure it is up
     time.sleep(10)
 
+
+@pytest.fixture
+def browser(app, request, server):
     # start headless webdriver
     vdisplay = Xvfb()
     vdisplay.start()


### PR DESCRIPTION
## Description of Changes
Bug:
* pytest 6.2.0 introduced a change that warns about unhandled thread exceptions, which likely means that the tests were erroring before we upgraded and just weren't aware of it: https://docs.pytest.org/en/7.1.x/changelog.html#id129
* Currently, we try to [create a new flask thread](https://github.com/OrcaCollective/OpenOversight/blob/8b00aecbdd4ae643bfdbdb354638b5e5dc19d99c/OpenOversight/tests/conftest.py#L676-L680) for each functional test and since they all try to use the same port, all but the first thread to throws this error:
```
    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))

tests/test_functional.py::test_officer_form_has_units_alpha_sorted
  /usr/local/lib/python3.10/site-packages/_pytest/threadexception.py:75: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-295 (run)
  
  Traceback (most recent call last):
    File "/usr/local/lib/python3.10/site-packages/werkzeug/serving.py", line 911, in prepare_socket
      s.bind(server_address)
  OSError: [Errno 98] Address already in use
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/usr/local/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
      self.run()
    File "/usr/local/lib/python3.10/threading.py", line 953, in run
      self._target(*self._args, **self._kwargs)
    File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 920, in run
      run_simple(t.cast(str, host), port, self, **options)
    File "/usr/local/lib/python3.10/site-packages/werkzeug/serving.py", line 1062, in run_simple
      s = prepare_socket(hostname, port)
    File "/usr/local/lib/python3.10/site-packages/werkzeug/serving.py", line 930, in prepare_socket
      sys.exit(1)
  SystemExit: 1
```

Change:
* Set flask app fixture scope to "session" so we don't try to run multiple instances on the same port

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
