### PR TITLE
Fix Selenium log path and remove unnecessary sleeps

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1387,17 +1387,6 @@ def privacy_oo():
     return render_template("privacy.html")
 
 
-@main.route("/shutdown")  # pragma: no cover
-def server_shutdown():  # pragma: no cover
-    if not current_app.testing:
-        abort(404)
-    shutdown = request.environ.get("werkzeug.server.shutdown")
-    if not shutdown:
-        abort(500)
-    shutdown()
-    return "Shutting down..."
-
-
 class IncidentApi(ModelView):
     model = Incident
     model_name = "incident"


### PR DESCRIPTION
## Description of Changes
Fix Selenium log path and remove unnecessary sleeps.

The Selenium `log_path` parameter was deprecated, causing a `geckodriver.log` file to be written as root to the docker container working directory, which is `OpenOversight/`. This in turn caused this error message to be thrown when `just fresh-start` was run after `just test-acceptance` (since the functional tests use Selenium):
```
$ just fresh-start
[...]
Building web
error checking context: 'no permission to read from '/home/sea-kelp/OpenOversight/OpenOversight/geckodriver.log''.
ERROR: Service 'web' failed to build : Build failed
error: Recipe `build` failed on line 24 with exit code 1
error: Recipe `fresh-start` failed on line 52 with exit code 1
```

This change uses the `Service` class introduced in Selenium 4 to pass the log path instead.

It also cleans up some unused code in our Selenium testing code.

## Notes for Deployment
None! (Changes only affect testing)

## Screenshots (if appropriate)
N/A

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
