### PR TITLE
Redirect to Officer page after deleting tag

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -917,19 +917,16 @@ def delete_tag(tag_id):
         if current_user.ac_department_id != tag.officer.department_id:
             abort(403)
 
+    officer_id = tag.officer_id
     try:
         db.session.delete(tag)
         db.session.commit()
         flash("Deleted this tag")
     except Exception:
         flash("Unknown error occurred")
-        exception_type, value, full_tback = sys.exc_info()
-        current_app.logger.error(
-            "Error classifying image: {}".format(
-                " ".join([str(exception_type), str(value), format_exc()])
-            )
-        )
-    return redirect(url_for("main.index"))
+        current_app.logger.exception("Unknown error occurred")
+
+    return redirect(url_for("main.officer_profile", officer_id=officer_id))
 
 
 @main.route("/tag/set_featured/<int:tag_id>", methods=["POST"])


### PR DESCRIPTION
## Description of Changes
Fixes #179.

## Notes for Deployment
None!

## Screenshots (if appropriate)
Officer page with tagged image
![1](https://user-images.githubusercontent.com/66500457/187140664-ff832011-3556-4cad-97b2-6b083bca54c5.png)

Image tag page
![2](https://user-images.githubusercontent.com/66500457/187140867-1feff819-b8de-407f-90f8-92d77791f6c8.png)

Redirects back to Officer page when "Delete Tag" is clicked
![3](https://user-images.githubusercontent.com/66500457/187140980-e76c55ab-3dd1-4a28-8461-79426402d122.png)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
