### PR TITLE
Prevent disabled users from logging in

### DIFF
--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -62,9 +62,13 @@ def login():
     if form.validate_on_submit():
         user = User.by_email(form.email.data).first()
         if user is not None and user.verify_password(form.password.data):
-            login_user(user, form.remember_me.data)
-            return redirect(request.args.get("next") or url_for("main.index"))
-        flash("Invalid username or password.")
+            if user.is_active:
+                login_user(user, form.remember_me.data)
+                return redirect(request.args.get("next") or url_for("main.index"))
+            else:
+                flash("User has been disabled.")
+        else:
+            flash("Invalid username or password.")
     else:
         current_app.logger.info(form.errors)
     return render_template("auth/login.html", form=form)

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -635,7 +635,7 @@ class User(UserMixin, BaseModel):
     @property
     def is_active(self):
         """Override UserMixin.is_active to prevent disabled users from logging in."""
-        return not (self.is_disabled)
+        return not self.is_disabled
 
     def __repr__(self):
         return "<User %r>" % self.username

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -632,6 +632,11 @@ class User(UserMixin, BaseModel):
         db.session.add(self)
         return True
 
+    @property
+    def is_active(self):
+        """Override UserMixin.is_active to prevent disabled users from logging in."""
+        return not (self.is_disabled)
+
     def __repr__(self):
         return "<User %r>" % self.username
 

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -14,6 +14,7 @@ import pytest
 from faker import Faker
 from flask import current_app, g
 from PIL import Image as Pimage
+from selenium.webdriver.firefox.options import Options as FirefoxOptions
 from selenium.webdriver.firefox.service import Service as FirefoxService
 from selenium.webdriver.firefox.webdriver import WebDriver as Firefox
 from xvfbwrapper import Xvfb
@@ -696,8 +697,11 @@ def browser(app, request, server):
     vdisplay = Xvfb()
     vdisplay.start()
 
+    options = FirefoxOptions()
+    options.headless = True
+
     service = FirefoxService(log_path="/tmp/geckodriver.log")
-    driver = Firefox(service=service)
+    driver = Firefox(options=options, service=service)
 
     yield driver
 

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -426,6 +426,16 @@ def add_mockdata(session):
     session.add(test_disabled_user)
     session.commit()
 
+    test_modified_disabled_user = models.User(
+        email="sam@example.org",
+        username="sam",
+        password="the yam",
+        confirmed=True,
+        is_disabled=True,
+    )
+    session.add(test_modified_disabled_user)
+    session.commit()
+
     test_addresses = [
         models.Location(
             street_name="Test St",

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -415,6 +415,16 @@ def add_mockdata(session):
     session.add(test_unconfirmed_user)
     session.commit()
 
+    test_disabled_user = models.User(
+        email="may@example.org",
+        username="may",
+        password="yam",
+        confirmed=True,
+        is_disabled=True,
+    )
+    session.add(test_disabled_user)
+    session.commit()
+
     test_addresses = [
         models.Location(
             street_name="Test St",

--- a/OpenOversight/tests/routes/route_helpers.py
+++ b/OpenOversight/tests/routes/route_helpers.py
@@ -27,6 +27,12 @@ def login_disabled_user(client):
     return rv
 
 
+def login_modified_disabled_user(client):
+    form = LoginForm(email="sam@example.org", password="the yam", remember_me=True)
+    rv = client.post(url_for("auth.login"), data=form.data, follow_redirects=True)
+    return rv
+
+
 def login_admin(client):
 
     form = LoginForm(email=ADMIN_EMAIL, password=ADMIN_PASSWORD, remember_me=True)

--- a/OpenOversight/tests/routes/route_helpers.py
+++ b/OpenOversight/tests/routes/route_helpers.py
@@ -14,6 +14,19 @@ def login_user(client):
     return rv
 
 
+def login_unconfirmed_user(client):
+    form = LoginForm(email="freddy@example.org", password="dog", remember_me=True)
+    rv = client.post(url_for("auth.login"), data=form.data, follow_redirects=False)
+    assert b"Invalid username or password" not in rv.data
+    return rv
+
+
+def login_disabled_user(client):
+    form = LoginForm(email="may@example.org", password="yam", remember_me=True)
+    rv = client.post(url_for("auth.login"), data=form.data, follow_redirects=True)
+    return rv
+
+
 def login_admin(client):
 
     form = LoginForm(email=ADMIN_EMAIL, password=ADMIN_PASSWORD, remember_me=True)


### PR DESCRIPTION
## Description of Changes
Fixes #165.

Currently when "Disabled?" is checked for a user, it doesn't actually have any effect. The user can still log in and do everything an active user can do.

This change prevents disabled users from logging in and overrides `UserMixin.is_active` to take the opposite boolean value as `is_disabled`. `is_authenticated`, which [is used](https://github.com/maxcountryman/flask-login/blob/3a2e24031562d4f4900b05644cec70d17cb84152/src/flask_login/utils.py#L284) by `@login_required` to determine whether a user is authorized to view a page, [takes its value](https://github.com/maxcountryman/flask-login/blob/6caf68f6b0e3f373b7ebdc6e7d3a5b2dedfc3a35/src/flask_login/mixins.py#L15-L17) from `is_active`.

## Notes for Deployment
None!

## Screenshots (if appropriate)
A failed login for a disabled user
![2](https://user-images.githubusercontent.com/66500457/188248628-ac0a010d-ec60-4803-a98f-04730cf624f6.png)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
