### PR TITLE
GitHub Pages, docs related just recipes, badges

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Generate docs
         run: |

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -26,23 +26,10 @@ jobs:
         run: |
             just install
             just make-docs
-            mv docs/_build/html /tmp/gh-pages
-
-      - name: Check out gh-pages branch
-        uses: actions/checkout@v3
-        with:
-          ref: gh-pages
 
       - name: Deploy docs
         uses: peaceiris/actions-gh-pages@v3.7.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: /tmp/gh-pages
+          publish_dir: ./docs/_build/html
           force_orphan: true
-
-      - name: Checkout branch again to enable cleaning
-        if: always()
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref_name }}
-

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,0 +1,50 @@
+name: Publish docs to github.io
+
+on:
+  push:
+    branches:
+      - main
+      - docs/*
+
+jobs:
+  publish-docs:
+    name: Publish developer docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup just
+        uses: extractions/setup-just@v1
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.10
+
+      - name: Generate docs
+        run: |
+            just install
+            just make-docs
+            mv docs/_build/html /tmp/gh-pages
+
+      - name: Check out gh-pages branch
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+
+        uses: actions/checkout@v2
+
+      - name: Deploy docs
+        uses: peaceiris/actions-gh-pages@v3.7.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: /tmp/gh-pages
+          force_orphan: true
+
+      - name: Checkout branch again to enable cleaning
+        if: always()
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref_name }}
+

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -18,7 +18,7 @@ jobs:
         uses: extractions/setup-just@v1
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.10
 

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -33,8 +33,6 @@ jobs:
         with:
           ref: gh-pages
 
-        uses: actions/checkout@v2
-
       - name: Deploy docs
         uses: peaceiris/actions-gh-pages@v3.7.3
         with:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Latest GHCR.io image version](https://ghcr-badge.herokuapp.com/orcacollective/openoversight/latest_tag?color=%230078D4)](https://ghcr.io/orcacollective/openoversight)
 [![Latest GHCR.io image size](https://ghcr-badge.herokuapp.com/orcacollective/openoversight/size?color=%230078D4)](https://ghcr.io/orcacollective/openoversight)
 
-# OpenOversight (Seattle Fork) 
+# OpenOversight (Seattle Fork)
 
 OpenOversight is a Lucy Parsons Labs project to improve law enforcement accountability through public and crowdsourced data. We maintain a database of officer demographic information and provide digital galleries of photographs. This is done to help people identify law enforcement officers for filing complaints and in order for the public to see work-related information about law enforcement officers that interact with the public.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 ![](docs/img/lpl-logo.png)
 
-# OpenOversight (Seattle Fork) [![Build Status](https://travis-ci.org/lucyparsons/OpenOversight.svg?branch=develop)](https://travis-ci.org/lucyparsons/OpenOversight) [![Coverage Status](https://coveralls.io/repos/github/lucyparsons/OpenOversight/badge.svg?branch=develop)](https://coveralls.io/github/lucyparsons/OpenOversight?branch=develop) [![Documentation Status](https://readthedocs.org/projects/openoversight/badge/?version=latest)](https://openoversight.readthedocs.io/en/latest/?badge=latest) [![Join the chat at https://gitter.im/OpenOversight/Lobby](https://badges.gitter.im/OpenOversight/Lobby.svg)](https://gitter.im/OpenOversight/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://github.com/OrcaCollective/OpenOversight/actions/workflows/publish.yml/badge.svg)](https://github.com/OrcaCollective/OpenOversight/actions/workflows/publish.yml)
+[![Documentation](https://img.shields.io/badge/docs-main-yellow)](https://orcacollective.github.io/OpenOversight/)
+[![Latest GHCR.io image version](https://ghcr-badge.herokuapp.com/orcacollective/openoversight/latest_tag?color=%230078D4)](https://ghcr.io/orcacollective/openoversight)
+[![Latest GHCR.io image size](https://ghcr-badge.herokuapp.com/orcacollective/openoversight/size?color=%230078D4)](https://ghcr.io/orcacollective/openoversight)
+
+# OpenOversight (Seattle Fork) 
 
 OpenOversight is a Lucy Parsons Labs project to improve law enforcement accountability through public and crowdsourced data. We maintain a database of officer demographic information and provide digital galleries of photographs. This is done to help people identify law enforcement officers for filing complaints and in order for the public to see work-related information about law enforcement officers that interact with the public.
 

--- a/justfile
+++ b/justfile
@@ -19,6 +19,11 @@ default:
 dotenv:
     @([ ! -f .env ] && cp .env.example .env) || true
 
+
+# Install dev dependencies into currently activated  python environment
+install:
+    pip3 install -r requirements-dev.txt
+
 # Build all containers
 build: dotenv
 	{{ DC }} build
@@ -95,3 +100,11 @@ backup location:
         -v {{ location }}:/backup \
         loomchild/volume-backup \
         backup openoversight-postgres-$(date '+%Y-%m-%d').tar.bz2
+
+# Build the docs using sphinx
+make-docs:
+    sphinx-build -b html docs/ docs/_build/html
+
+# Build & serve the docs using a live server
+serve-docs:
+    sphinx-autobuild docs/ docs/_build/html


### PR DESCRIPTION
## Description of Changes
Fixes #191

This PR adds a few just recipes related to building & serving documents. It also sets up a GitHub action which publishes the docs on every commit to `main` (or branch that starts with `docs/`).

Check it out here! https://orcacollective.github.io/OpenOversight/

It took this as an opportunity to update the README badges as well, and added a few new ones :rocket:

## Notes for Deployment

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/10214785/188258030-bd46e0c0-ef81-43e4-b158-638444d21657.png)


## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
