### PR TITLE
make compose stack work on docker 20.10.18 and compose 1.25.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 POSTGRES_PASSWORD=terriblepassword
-SQLALCHEMY_DATABASE_URI="postgresql://openoversight:terriblepassword@postgres/openoversight"
+SQLALCHEMY_DATABASE_URI=postgresql://openoversight:terriblepassword@postgres/openoversight
 SECRET_KEY=testcsrfkey
 S3_BUCKET_NAME=spd-copwatch
 AWS_ACCESS_KEY_ID=minio

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 
 services:
   postgres:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 
 services:
   web:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 
 services:
   postgres:


### PR DESCRIPTION
## Description of Changes

I had to make these changes in order for "just fresh-start" to work on my Ubuntu 20.04 machine with the docker versions mentioned.

The error I was getting was "services.app.build contains unsupported option: 'target'". Here's some info suggesting bumping the compose file version: https://github.com/docker/compose/issues/5714

Also had to remove the quotes in .env.example otherwise the create_db.py script was using them as part of the value.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
