### PR TITLE
Fix incident description truncation

### DIFF
--- a/OpenOversight/app/static/js/incidentDescription.js
+++ b/OpenOversight/app/static/js/incidentDescription.js
@@ -1,12 +1,11 @@
 $(document).ready(function() {
-    let overflow_length = 700;
+    const overflow_length = 700;
     $(".incident-description").each(function () {
         let description = this;
         let incidentId = $( this ).data("incident");
-        if (description.innerHTML.length < overflow_length) {
+        if (description.innerHTML.length <= overflow_length) {
             $("#description-overflow-row_" + incidentId).hide();
-        }
-        if(description.innerHTML.length > overflow_length) {
+        } else {
             let originalDescription = description.innerHTML;
             // Convert the innerHTML into a string, and truncate it to overflow length
             const sub = description.innerHTML.substring(0, overflow_length)
@@ -16,8 +15,12 @@ $(document).ready(function() {
             // Tags could be variable length, so next find the index of the first
             // ">" after the start of the closing bracket.
             const lastTag = sub.substring(cutoff).indexOf(">")
-            // Lastly, trim the HTML to the end of the closing tag
-            description.innerHTML = sub.substring(0, cutoff + lastTag + 1) + "…";
+            // Lastly, trim the HTML to the end of the closing tag, if a tag was found
+            if (cutoff == -1 || lastTag == -1) {
+                description.innerHTML = sub;
+            } else {
+                description.innerHTML = sub.substring(0, cutoff + lastTag + 1) + "…";
+            }
             $(`#description-overflow-button_${incidentId}`).on('click', function(event) {
                 event.stopImmediatePropagation();
                 description.innerHTML = originalDescription;

--- a/OpenOversight/app/static/js/incidentDescription.js
+++ b/OpenOversight/app/static/js/incidentDescription.js
@@ -8,19 +8,21 @@ $(document).ready(function() {
         } else {
             let originalDescription = description.innerHTML;
             // Convert the innerHTML into a string, and truncate it to overflow length
-            const sub = description.innerHTML.substring(0, overflow_length)
+            const sub = description.innerHTML.substring(0, overflow_length);
             // In order to make the cutoff clean, we will want to truncate *after*
             // the end of the last HTML tag. So first we need to find the last tag.
-            const cutoff = sub.lastIndexOf("</")
+            const cutoff = sub.lastIndexOf("</");
             // Tags could be variable length, so next find the index of the first
             // ">" after the start of the closing bracket.
-            const lastTag = sub.substring(cutoff).indexOf(">")
+            const lastTag = sub.substring(cutoff).indexOf(">");
             // Lastly, trim the HTML to the end of the closing tag, if a tag was found
             if (cutoff == -1 || lastTag == -1) {
                 description.innerHTML = sub;
             } else {
-                description.innerHTML = sub.substring(0, cutoff + lastTag + 1) + "…";
+                description.innerHTML = sub.substring(0, cutoff + lastTag + 1);
             }
+            description.innerHTML += "…";
+
             $(`#description-overflow-button_${incidentId}`).on('click', function(event) {
                 event.stopImmediatePropagation();
                 description.innerHTML = originalDescription;

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -176,6 +176,27 @@ def test_incident_detail_display_read_more_button_for_descriptions_over_cutoff(
 
 
 @pytest.mark.acceptance
+def test_incident_detail_truncate_description_for_descriptions_over_cutoff(
+    mockdata, browser
+):
+    # Navigate to profile page for officer with short and long incident descriptions
+    browser.get("http://localhost:5000/officer/1")
+
+    incident_long_descrip = Incident.query.filter(
+        func.length(Incident.description) > DESCRIPTION_CUTOFF
+    ).one_or_none()
+    incident_id = str(incident_long_descrip.id)
+
+    # Check that the text is truncated and contains more than just the ellipsis
+    truncated_text = browser.find_element(
+        "id", "incident-description_" + incident_id
+    ).text
+    assert "…" in truncated_text
+    # Include buffer for jinja rendered spaces
+    assert DESCRIPTION_CUTOFF + 20 > len(truncated_text) > 100
+
+
+@pytest.mark.acceptance
 def test_incident_detail_do_not_display_read_more_button_for_descriptions_under_cutoff(
     mockdata, browser
 ):


### PR DESCRIPTION
## Description of Changes
Fix a couple minor incident truncation bugs I found while fixing the Selenium issue.

For incident descriptions that don't contain html tags (like in testing or if we decide to add a new department), we currently only display an ellipses in the incident description on the officer page.

Additionally, there's also a minor bug where if the incident description is exactly 700 characters long, it will neither hide the expand button nor truncate the text.

## Notes for Deployment
N/A

## Screenshots (if appropriate)
**=700** and **Without Tags (>700)** cases were fixed, while others stayed the same.

| Scenario                     | Before                                                          | After                                                                             |
|------------------------------|----------------------------------------------------------|-----------------------------------------------------------------------|
| <700 description         | ![1](https://user-images.githubusercontent.com/66500457/193378827-8e6abfb0-2210-4dfb-a936-8f96e4eb5954.png) | ![1](https://user-images.githubusercontent.com/66500457/193378855-712b2b12-3a05-4c2b-9a55-31db2542b439.png) |
| =700  description        |  ![2](https://user-images.githubusercontent.com/66500457/193378833-808f3bd3-feaa-4625-9fc2-a6bcf391cc62.png) | ![2](https://user-images.githubusercontent.com/66500457/193378859-3bc2c381-3862-4191-94be-376e3654d7fb.png) |
| Without tags (>700)    |  ![3](https://user-images.githubusercontent.com/66500457/193378842-51479cbd-7bb4-4ce6-ac7f-c31d52752594.png) | ![3](https://user-images.githubusercontent.com/66500457/193379535-3c49f403-bd4f-46cc-9e8f-b0b5871738a8.png) |
| With tags (>700)         | ![4](https://user-images.githubusercontent.com/66500457/193378844-5025e6fe-8493-4d4a-9909-29cb7e41ba85.png) | ![4](https://user-images.githubusercontent.com/66500457/193378872-60d58dab-e7a6-4894-a3bf-16734e824cbe.png) |


## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
