### PR TITLE
Store next param in session cookie

### DIFF
--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -72,9 +72,8 @@ def login():
         if user is not None and user.verify_password(form.password.data):
             if user.is_active:
                 login_user(user, form.remember_me.data)
-                return redirect(
-                    validate_redirect_url(session.get("next")) or url_for("main.index")
-                )
+                next_url = validate_redirect_url(session.get("next"))
+                return redirect(next_url or url_for("main.index"))
             else:
                 flash("User has been disabled.")
         else:

--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -1,10 +1,18 @@
-from flask import current_app, flash, redirect, render_template, request, url_for
+from flask import (
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 from flask_login import current_user, login_required, login_user, logout_user
 
 from .. import sitemap
 from ..email import send_email
 from ..models import User, db
-from ..utils import set_dynamic_default
+from ..utils import set_dynamic_default, validate_redirect_url
 from . import auth
 from .forms import (
     ChangeDefaultDepartmentForm,
@@ -64,7 +72,9 @@ def login():
         if user is not None and user.verify_password(form.password.data):
             if user.is_active:
                 login_user(user, form.remember_me.data)
-                return redirect(url_for("main.index"))
+                return redirect(
+                    validate_redirect_url(session.get("next")) or url_for("main.index")
+                )
             else:
                 flash("User has been disabled.")
         else:

--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -46,6 +46,10 @@ class BaseConfig(object):
     # User settings
     APPROVE_REGISTRATIONS = os.environ.get("APPROVE_REGISTRATIONS", False)
 
+    # Use session cookie to store URL to redirect to after login
+    # https://flask-login.readthedocs.io/en/latest/#customizing-the-login-process
+    USE_SESSION_FOR_NEXT = True
+
     SEED = 666
 
     @staticmethod

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -12,6 +12,7 @@ from flask import (
     redirect,
     render_template,
     request,
+    session,
     url_for,
 )
 from flask_login import current_user, login_required, login_user
@@ -63,6 +64,7 @@ from ..utils import (
     serve_image,
     set_dynamic_default,
     upload_image_to_s3_and_store_in_db,
+    validate_redirect_url,
 )
 from . import downloads, main
 from .choices import AGE_CHOICES, GENDER_CHOICES, RACE_CHOICES
@@ -106,7 +108,11 @@ def static_routes():
 
 
 def redirect_url(default="index"):
-    return request.referrer or url_for(default)
+    return (
+        validate_redirect_url(session.get("next"))
+        or request.referrer
+        or url_for(default)
+    )
 
 
 @sitemap_include
@@ -180,7 +186,7 @@ def get_started_labeling():
         user = User.by_email(form.email.data).first()
         if user is not None and user.verify_password(form.password.data):
             login_user(user, form.remember_me.data)
-            return redirect(url_for("main.index"))
+            return redirect(url_for("main.get_started_labeling"))
         flash("Invalid username or password.")
     else:
         current_app.logger.info(form.errors)

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -8,6 +8,7 @@ from distutils.util import strtobool
 from io import BytesIO
 from traceback import format_exc
 from typing import Optional
+from urllib.parse import urlparse
 from urllib.request import urlopen
 
 import boto3
@@ -740,3 +741,19 @@ def normalize_gender(input_gender):
     }
 
     return normalized_genders.get(input_gender.lower().strip())
+
+
+def validate_redirect_url(url: Optional[str]) -> Optional[str]:
+    """
+    Check that a url does not redirect to another domain.
+    :param url: the url to be checked
+    :return: the url if validated, otherwise `None`
+    """
+    if not url:
+        return None
+
+    parsed = urlparse(url)
+    if parsed.scheme or parsed.netloc:
+        return None
+
+    return url

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -344,6 +344,7 @@ def test_filter_by_form_filter_unit(
     "url,is_valid",
     [
         ("/images/1", True),
+        ("/officer/1?with_params=true", True),
         ("//google.com", False),
         ("http://google.com", False),
         ("https://google.com/?q=oo", False),

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -11,6 +11,7 @@ from OpenOversight.app.utils import (
     crop_image,
     filter_by_form,
     upload_image_to_s3_and_store_in_db,
+    validate_redirect_url,
 )
 from OpenOversight.tests.routes.route_helpers import login_user
 
@@ -337,3 +338,21 @@ def test_filter_by_form_filter_unit(
         if has_officers_with_no_unit:
             found = found or any([a.unit_id is None for a in officer.assignments])
         assert found
+
+
+@pytest.mark.parametrize(
+    "url,is_valid",
+    [
+        ("/images/1", True),
+        ("//google.com", False),
+        ("http://google.com", False),
+        ("https://google.com/?q=oo", False),
+        ("http://localhost:3000", False),
+    ],
+)
+def test_validate_redirect_url(url, is_valid):
+    result = validate_redirect_url(url)
+    if is_valid:
+        assert result == url
+    else:
+        assert result is None


### PR DESCRIPTION
## Description of Changes
Sequel to #217! :partying_face: 

I found out that the Flask-Login `@login_required` annotation we use automatically sets the `next` parameter to redirect back to the page once the user is logged in.

This change sets the Flask-Login [`USE_SESSION_FOR_NEXT` option](https://flask-login.readthedocs.io/en/latest/#customizing-the-login-process) which stores the `next` url in the session cookie instead of reading it from the url, which effectively mitigates the concerns from #217.

I also added some validation to the redirect url to make sure that we are not redirecting to an external url.

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
