### PR TITLE
Show full size image on tag page

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,4 +26,6 @@ jobs:
         run: |
           just build
           just test
+          just up
           just test-acceptance
+          just down

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,6 +26,5 @@ jobs:
         run: |
           just build
           just test
-          just up
+          just up minio
           just test-acceptance
-          just down

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,5 +26,6 @@ jobs:
         run: |
           just build
           just test
-          just up minio
+          just up
           just test-acceptance
+          just down

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -451,14 +451,14 @@ def display_submission(image_id):
 
 
 @main.route("/tag/<int:tag_id>")
-@login_required
 def display_tag(tag_id):
+    jsloads = ["js/tag.js"]
     try:
         tag = Face.query.filter_by(id=tag_id).one()
-        proper_path = serve_image(tag.image.filepath)
+        proper_path = serve_image(tag.original_image.filepath)
     except NoResultFound:
         abort(404)
-    return render_template("tag.html", face=tag, path=proper_path)
+    return render_template("tag.html", face=tag, path=proper_path, jsloads=jsloads)
 
 
 @main.route("/image/classify/<int:image_id>/<int:contains_cops>", methods=["POST"])

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -582,3 +582,15 @@ tr:hover .row-actions {
     min-width: 200px;
     min-height: 200px;
 }
+
+.face-wrap {
+    margin: auto;
+    position: relative;
+}
+
+#face-tag-frame {
+    position: absolute;
+    border: 2px solid crimson;
+    visibility: hidden;
+    width: auto
+}

--- a/OpenOversight/app/static/js/tag.js
+++ b/OpenOversight/app/static/js/tag.js
@@ -1,0 +1,26 @@
+$(document).ready(function () {
+    const img = $("#face-img")
+    const frame = $("#face-tag-frame")
+
+    // To prevent hi-res images from taking over the entire page, the image is being shown
+    // in a responsive element. This means we need to compute the tag frame dimensions using
+    // percentages so it will scale if the page size changes.
+
+    // To do this, we're dividing the tag dimensions by the image's actual width/height and
+    // multiplying by 100.
+    const tagWidth = parseInt(img.data("width")) / img[0].naturalWidth * 100
+    const tagHeight = parseInt(img.data("height")) / img[0].naturalHeight * 100
+    const tagLeft = parseInt(img.data("left")) / img[0].naturalWidth * 100
+    const tagTop = parseInt(img.data("top")) / img[0].naturalHeight * 100
+
+    frame.css({
+        height: tagHeight + "%",
+        width: tagWidth + "%",
+        left: tagLeft + "%",
+        top: tagTop + "%",
+        visibility: "visible",
+    })
+
+    // Make sure wrapper does not expand larger than image
+    $(".face-wrap").css("maxWidth", img[0].naturalWidth + "px")
+});

--- a/OpenOversight/app/templates/partials/officer_faces.html
+++ b/OpenOversight/app/templates/partials/officer_faces.html
@@ -1,6 +1,6 @@
 {% for path in paths %}
 
-{# Don't try to link if only image is placeholder #}
+{# Don't try to link if only image is the placeholder #}
 {% if faces %}
 <a href="{{ url_for('main.display_tag', tag_id=faces[loop.index - 1].id) }}">
 {% endif %}

--- a/OpenOversight/app/templates/partials/officer_faces.html
+++ b/OpenOversight/app/templates/partials/officer_faces.html
@@ -1,13 +1,14 @@
 {% for path in paths %}
 
-{% if is_admin_or_coordinator and faces %}
-  <a href="{{ url_for('main.display_tag', tag_id=faces[loop.index - 1].id) }}">
+{# Don't try to link if only image is placeholder #}
+{% if faces %}
+<a href="{{ url_for('main.display_tag', tag_id=faces[loop.index - 1].id) }}">
 {% endif %}
 
-<img class="officer-face" src="{{ path }}" alt="Submission">
+  <img class="officer-face" src="{{ path }}" alt="Submission">
 
-{% if is_admin_or_coordinator and faces %}
-  </a>
+{% if faces %}
+</a>
 {% endif %}
 
 {% endfor %}

--- a/OpenOversight/app/templates/tag.html
+++ b/OpenOversight/app/templates/tag.html
@@ -9,15 +9,36 @@
 
 </div>
 
+
 <div class="container">
   <div class="row">
-    <div class="col-sm-6 col-md-4">
-      <img src="{{ path }}" />
-      <br>
+    <div class="col-sm-12">
+      You can download the full officer photo by clicking the image below:
+    </div>
+  </div>
+
+  <br>
+
+  <div class="row">
+    <div class="col-sm-12 col-md-12">
+      <a href="{{ path }}" rel="noopener noreferrer">
+        <div class="face-wrap">
+          <img id="face-img"
+            data-left="{{ face.face_position_x }}"
+            data-top="{{ face.face_position_y }}"
+            data-width="{{ face.face_width }}"
+            data-height="{{ face.face_height }}"
+            src="{{ path }}" />
+          <div id="face-tag-frame"></div>
+        </div>
+      </a>
     </div>
   </div>
 </div>
 
+<br>
+
+{% if current_user and current_user.is_authenticated %}
 <div class="container">
   <div class="row">
     <div class="col-sm-6 col-md-4">
@@ -27,9 +48,14 @@
           <table class="table table-hover">
             <tbody>
               <tr>
-                <td><b>Image ID</b></td>
+                <td><b>Cropped Image ID</b></td>
                 <td><a href="{{ url_for('main.display_submission', image_id=face.image.id) }}">
                     {{ face.image.id }}</a></td>
+              </tr>
+              <tr>
+                <td><b>Original Image ID</b></td>
+                <td><a href="{{ url_for('main.display_submission', image_id=face.original_image.id) }}">
+                    {{ face.original_image.id }}</a></td>
               </tr>
               <tr>
                 <td><b>Department</b></td>
@@ -91,9 +117,7 @@
         </div>
       </div>
     </div>
-
   </div>
-
 </div>
-
+{% endif %}
 {% endblock %}

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -256,8 +256,9 @@ def get_random_image(image_query):
 
 
 def serve_image(filepath):
-    # Custom change for development
-    if "minio" in filepath:
+    # Custom change for development. Do not replace minio with localhost in
+    # automated tests since these run inside the docker container.
+    if "minio" in filepath and not current_app.config.get("TESTING"):
         filepath = filepath.replace("minio", "localhost")
     if "http" in filepath:
         return filepath

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -28,6 +28,7 @@ PROJECT_ROOT = os.path.abspath(os.curdir)
         ("/tagger_find"),
         ("/label"),
         ("/tutorial"),
+        ("/tag/1"),
     ],
 )
 def test_routes_ok(route, client, mockdata):
@@ -44,7 +45,6 @@ def test_routes_ok(route, client, mockdata):
         ("/cop_face/department/1"),
         ("/image/1"),
         ("/image/tagged/1"),
-        ("/tag/1"),
     ],
 )
 def test_route_login_required(route, client, mockdata):
@@ -123,6 +123,10 @@ def test_user_can_view_tag(mockdata, client, session):
 
         rv = client.get(url_for("main.display_tag", tag_id=1), follow_redirects=True)
         assert b"Tag" in rv.data
+
+        # Check that tag frame position is specified
+        for attribute in (b"data-top", b"data-left", b"data-width", b"data-height"):
+            assert attribute in rv.data
 
 
 def test_admin_can_delete_tag(mockdata, client, session):

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -1,5 +1,6 @@
 from __future__ import division
 
+import os
 from contextlib import contextmanager
 
 import pytest
@@ -297,3 +298,98 @@ def test_edit_officer_form_coerces_none_race_or_gender_to_not_sure(mockdata, bro
     selected_option = select.first_selected_option
     selected_text = selected_option.text
     assert selected_text == "Not Sure"
+
+
+@pytest.mark.acceptance
+def test_image_classification_and_tagging(mockdata, browser):
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+    img_path = os.path.join(test_dir, "images/200Cat.jpeg")
+
+    login_admin(browser)
+
+    # 1. Create new department (to avoid mockdata)
+    browser.get("http://localhost:5000/department/new")
+    wait_for_page_load(browser)
+    browser.find_element(By.ID, "name").send_keys("Auburn Police Department")
+    browser.find_element(By.ID, "short_name").send_keys("APD")
+    browser.find_element(By.ID, "submit").click()
+    wait_for_page_load(browser)
+
+    # 2. Add a new officer
+    browser.get("http://localhost:5000/officer/new")
+    wait_for_page_load(browser)
+
+    dept_select = Select(browser.find_element("id", "department"))
+    dept_select.select_by_visible_text("Auburn Police Department")
+    dept_id = dept_select.first_selected_option.get_attribute("value")
+
+    browser.find_element(By.ID, "first_name").send_keys("Officer")
+    browser.find_element(By.ID, "last_name").send_keys("Friendly")
+    browser.find_element(By.ID, "submit").click()
+
+    wait_for_page_load(browser)
+    # expected url: http://localhost:5000/submit_officer_images/officer/<id>
+    officer_id = browser.current_url.split("/")[-1]
+
+    # 3. Submit an image
+    browser.get("http://localhost:5000/submit")
+    wait_for_page_load(browser)
+
+    Select(browser.find_element("id", "department")).select_by_value(dept_id)
+
+    # Submit files in selenium: https://stackoverflow.com/a/61566075
+    wait_for_element(browser, By.CLASS_NAME, "dz-hidden-input")
+    upload = browser.find_element(By.CLASS_NAME, "dz-hidden-input")
+    upload.send_keys(img_path)
+    wait_for_element(browser, By.CLASS_NAME, "dz-success")
+
+    # 4. Classify the uploaded image
+    browser.get(f"http://localhost:5000/sort/department/{dept_id}")
+
+    # Check that image loaded correctly: https://stackoverflow.com/a/36296478
+    wait_for_element(browser, By.TAG_NAME, "img")
+    image = browser.find_element(By.TAG_NAME, "img")
+    assert image.get_attribute("complete") == "true"
+    assert int(image.get_attribute("naturalHeight")) > 0
+
+    browser.find_element(By.ID, "answer-yes").click()
+
+    wait_for_page_load(browser)
+    page_text = browser.find_element(By.TAG_NAME, "body").text
+    assert "All images have been classfied!" in page_text
+
+    # 5. Identify the new officer in the uploaded image
+    browser.get(f"http://localhost:5000/cop_face/department/{dept_id}")
+    wait_for_page_load(browser)
+    browser.find_element(By.ID, "officer_id").send_keys(officer_id)
+    browser.find_element(By.CSS_SELECTOR, "input[value='Add identified face']").click()
+
+    wait_for_page_load(browser)
+    page_text = browser.find_element(By.TAG_NAME, "body").text
+    assert "Tag added to database" in page_text
+
+    # 6. Log out as admin
+    browser.get("http://localhost:5000/auth/logout")
+    wait_for_page_load(browser)
+
+    # 7. Check that the tag appears on the officer page
+    browser.get(f"http://localhost:5000/officer/{officer_id}")
+    wait_for_page_load(browser)
+    browser.find_element(By.CSS_SELECTOR, "a > img.officer-face").click()
+
+    wait_for_page_load(browser)
+    image = browser.find_element(By.TAG_NAME, "img")
+    frame = browser.find_element(By.ID, "face-tag-frame")
+
+    # 8. Check that the tag frame is fully contained within the image
+    assert image.location["x"] <= frame.location["x"]
+    assert image.location["y"] <= frame.location["y"]
+    assert (
+        image.location["x"] + image.size["width"]
+        >= frame.location["x"] + frame.size["width"]
+    )
+    assert (
+        image.location["y"] + image.size["height"]
+        >= frame.location["y"] + frame.size["height"]
+    )
+    assert image.location["y"] <= frame.location["y"]


### PR DESCRIPTION
## Description of Changes
Fixes #202 and fixes #203. Makes the full-size image available on the tag page to users who are not logged in

As a note, digitalocean spaces/minio doesn't seem to set `Context-Type` so clicking the image link triggers an image download

## Notes for Deployment
None!

## Screenshots (if appropriate)
**Officer Page**:
![1](https://user-images.githubusercontent.com/66500457/197273973-aabfc820-7ce4-4d05-b56d-f13208a2572b.png)

**Tag Detail Page (Logged In)**:
![2](https://user-images.githubusercontent.com/66500457/197273988-09d9a3ea-4989-4f23-80b4-6ccf2f7b6701.png)

**Tag Detail Page (Not Logged In)**:
![3](https://user-images.githubusercontent.com/66500457/197274004-2be27dce-a2b7-495a-9d4f-064449f66e08.png)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
