### PR TITLE
Update mc commands to use new `anonymous` subcommand

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,7 +35,7 @@ services:
       sleep 5;
       /usr/bin/mc config host add myminio http://minio:9000 minio ${MINIO_ROOT_PASSWORD};
       /usr/bin/mc mb myminio/${S3_BUCKET_NAME};
-      /usr/bin/mc policy set public myminio/${S3_BUCKET_NAME};
+      /usr/bin/mc anonymous set public myminio/${S3_BUCKET_NAME};
       exit 0;
       "
 


### PR DESCRIPTION
## Description of Changes
This PR fixes an issue with newer versions of `mc policy` no longer exists (it has been under the subcommand `anonymous` for several years): https://github.com/minio/mc/pull/4276

## Notes for Deployment
None, only used for local dev.

## Tests and linting

 - [ ] I have rebased my changes on `main`

 - [ ] `just lint` passes

 - [ ] `just test` passes
