### PR TITLE
Fix upload content-type detection

### DIFF
--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -633,6 +633,7 @@ def upload_image_to_s3_and_store_in_db(image_buf, user_id, department_id=None):
         return existing_image
     try:
         new_filename = "{}.{}".format(hash_img, image_type)
+        scrubbed_image_buf.seek(0)
         url = upload_obj_to_s3(scrubbed_image_buf, new_filename)
         new_image = Image(
             filepath=url,


### PR DESCRIPTION
## Description of Changes
We currently read the `scrubbed_image_buf` without seeking the cursor back to the start of the file so filetype detection ends up looking at an empty buffer. This causes our uploaded images to have their content types set to `image/None`.

This change fixes that!

## Notes for Deployment
None (We should eventually figure out how to fix the existing images?)

## Screenshots (if appropriate)
N/A

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
