### PR TITLE
Allow volunteers to set the featured tag

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -937,17 +937,12 @@ def delete_tag(tag_id):
 
 @main.route("/tag/set_featured/<int:tag_id>", methods=["POST"])
 @login_required
-@ac_or_admin_required
 def set_featured_tag(tag_id):
     tag = Face.query.filter_by(id=tag_id).first()
 
     if not tag:
         flash("Tag not found")
         abort(404)
-
-    if not current_user.is_administrator and current_user.is_area_coordinator:
-        if current_user.ac_department_id != tag.officer.department_id:
-            abort(403)
 
     # Set featured=False on all other tags for the same officer
     for face in Face.query.filter_by(officer_id=tag.officer_id).all():
@@ -960,12 +955,8 @@ def set_featured_tag(tag_id):
         flash("Successfully set this tag as featured")
     except Exception:
         flash("Unknown error occurred")
-        exception_type, value, full_tback = sys.exc_info()
-        current_app.logger.error(
-            "Error setting featured tag: {}".format(
-                " ".join([str(exception_type), str(value), format_exc()])
-            )
-        )
+        current_app.logger.exception("Error setting featured tag")
+
     return redirect(url_for("main.officer_profile", officer_id=tag.officer_id))
 
 

--- a/OpenOversight/app/templates/tag.html
+++ b/OpenOversight/app/templates/tag.html
@@ -58,6 +58,16 @@
             </tbody>
           </table>
 
+          <h3>Set as featured tag</h3>
+          <p>
+            <form action="{{ url_for('main.set_featured_tag', tag_id=face.id) }}" method="post">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+              <button type="submit" name="action" class="btn btn-primary" {% if face.featured %}disabled{% endif %}>
+                Set as featured tag
+              </button>
+            </form>
+          </p>
+
           {% if current_user.is_administrator
             or (current_user.is_area_coordinator and current_user.ac_department_id == face.image.department_id) %}
           <h3>Remove tag <small>Admin only</small></h3>
@@ -76,15 +86,6 @@
                   Tag this image
                 </button>
               </a>
-            </form>
-          </p>
-          <h3>Set as featured tag <small>Admin only</small></h3>
-          <p>
-            <form action="{{ url_for('main.set_featured_tag', tag_id=face.id) }}" method="post">
-              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-              <button type="submit" name="action" class="btn btn-primary" {% if face.featured %}disabled{% endif %}>
-                Set as featured tag
-              </button>
             </form>
           </p>
           {% endif %}

--- a/OpenOversight/app/templates/tag.html
+++ b/OpenOversight/app/templates/tag.html
@@ -58,6 +58,7 @@
             </tbody>
           </table>
 
+          {% if current_user and not current_user.is_anonymous %}
           <h3>Set as featured tag</h3>
           <p>
             <form action="{{ url_for('main.set_featured_tag', tag_id=face.id) }}" method="post">
@@ -67,6 +68,7 @@
               </button>
             </form>
           </p>
+          {% endif %}
 
           {% if current_user.is_administrator
             or (current_user.is_area_coordinator and current_user.ac_department_id == face.image.department_id) %}

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -306,59 +306,14 @@ def test_user_is_redirected_to_correct_department_after_tagging(
         assert department.name in rv.data.decode("utf-8")
 
 
-def test_admin_can_set_featured_tag(mockdata, client, session):
+def test_user_can_set_featured_tag(mockdata, client, session):
     with current_app.test_request_context():
-        login_admin(client)
+        login_user(client)
 
         rv = client.post(
             url_for("main.set_featured_tag", tag_id=1), follow_redirects=True
         )
         assert b"Successfully set this tag as featured" in rv.data
-
-
-def test_ac_can_set_featured_tag_in_their_dept(mockdata, client, session):
-    with current_app.test_request_context():
-        login_ac(client)
-
-        tag = Face.query.filter(Face.officer.has(department_id=AC_DEPT)).first()
-        tag_id = tag.id
-
-        rv = client.post(
-            url_for("main.set_featured_tag", tag_id=tag_id), follow_redirects=True
-        )
-        assert b"Successfully set this tag as featured" in rv.data
-
-        featured_tag = (
-            Face.query.filter(Face.officer_id == tag.officer_id)
-            .filter(Face.featured == True)  # noqa: E712
-            .one_or_none()
-        )
-        assert featured_tag is not None
-
-
-def test_ac_cannot_set_featured_tag_not_in_their_dept(mockdata, client, session):
-    with current_app.test_request_context():
-        login_ac(client)
-
-        tag = (
-            Face.query.join(Face.officer, aliased=True)
-            .except_(Face.query.filter(Face.officer.has(department_id=AC_DEPT)))
-            .first()
-        )
-
-        tag_id = tag.id
-
-        rv = client.post(
-            url_for("main.set_featured_tag", tag_id=tag_id), follow_redirects=True
-        )
-        assert rv.status_code == 403
-
-        featured_tag = (
-            Face.query.filter(Face.officer_id == tag.officer_id)
-            .filter(Face.featured == True)  # noqa: E712
-            .one_or_none()
-        )
-        assert featured_tag is None
 
 
 @patch(
@@ -367,7 +322,7 @@ def test_ac_cannot_set_featured_tag_not_in_their_dept(mockdata, client, session)
 )
 def test_featured_tag_replaces_others(mockdata, client, session):
     with current_app.test_request_context():
-        login_admin(client)
+        login_user(client)
 
         tag1 = Face.query.first()
         officer = Officer.query.filter_by(id=tag1.officer_id).one()

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -316,6 +316,11 @@ def test_user_can_set_featured_tag(mockdata, client, session):
         assert b"Successfully set this tag as featured" in rv.data
 
 
+def test_can_set_featured_tag_login_required(mockdata, client, session):
+    rv = client.post("/tag/set_featured/1", follow_redirects=False)
+    assert rv.status_code == 302
+
+
 @patch(
     "OpenOversight.app.utils.serve_image",
     MagicMock(return_value=PROJECT_ROOT + "/app/static/images/test_cop1.png"),


### PR DESCRIPTION
## Description of Changes
Fixes #70.

Allow volunteers to set the featured tag

## Notes for Deployment
Volunteers won't be linked to the tag page until #220 has been merged

## Screenshots (if appropriate)
When logged in as a volunteer:

Before:
![1](https://user-images.githubusercontent.com/66500457/198936727-330627a4-38fb-4fa2-8607-deb3795fdeaa.png)

"Set as featured tag" shows up on tag page:
![2](https://user-images.githubusercontent.com/66500457/198938756-54066293-017b-42a1-9220-328947921f63.png)

Tag has been set as featured image:
![3](https://user-images.githubusercontent.com/66500457/198938762-814903e2-ce97-4c8e-a9af-62fdfcb44224.png)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
