### PR TITLE
Rename "Area coordinator department" in the UI

### DIFF
--- a/OpenOversight/app/auth/forms.py
+++ b/OpenOversight/app/auth/forms.py
@@ -114,15 +114,15 @@ class ChangeDefaultDepartmentForm(Form):
 
 
 class EditUserForm(Form):
-    is_area_coordinator = BooleanField(
-        "Is area coordinator?", false_values={"False", "false", ""}
-    )
     ac_department = QuerySelectField(
-        "Department",
+        "Assigned Department",
         validators=[Optional()],
         query_factory=dept_choices,
         get_label="name",
         allow_blank=True,
+    )
+    is_area_coordinator = BooleanField(
+        "Is area coordinator?", false_values={"False", "false", ""}
     )
     is_administrator = BooleanField(
         "Is administrator?", false_values={"False", "false", ""}

--- a/OpenOversight/app/templates/auth/users.html
+++ b/OpenOversight/app/templates/auth/users.html
@@ -22,7 +22,7 @@
 					<th>Email</th>
 					<th>Status</th>
 					<th>Is Area Coordinator?</th>
-					<th>Area Coordinator Department</th>
+					<th>Assigned Department</th>
 					<th>Is Administator?</th>
 
 				</tr>


### PR DESCRIPTION
## Description of Changes
Fixes #118.

Change "Area Coordinator Department" to "Assigned Department"

## Notes for Deployment
None!

## Screenshots (if appropriate)

|                          | Before | After |
|----------------------|----------|--------|
| Edit user page  |  ![1](https://user-images.githubusercontent.com/66500457/198942894-312e929b-5d94-4cbd-a68e-0ee927cf0486.png) | ![2](https://user-images.githubusercontent.com/66500457/198942927-e580fa0d-57f8-447b-aa32-c0e629634dfd.png) |
| Users page       | ![3](https://user-images.githubusercontent.com/66500457/198943034-f3121328-82a5-40da-a7fc-5caf49ba595b.png) | ![4](https://user-images.githubusercontent.com/66500457/198943044-3fd619e7-7d46-4df4-bff1-ab36d6bfad7d.png) |


## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
