### PR TITLE
Add backlink to tag detail page

### DIFF
--- a/OpenOversight/app/templates/tag.html
+++ b/OpenOversight/app/templates/tag.html
@@ -4,6 +4,11 @@
 <div class="container" role="main">
 
   <div class="page-header">
+    <ol class="breadcrumb">
+      <li><a href="{{url_for('main.list_officer',department_id=face.officer.department.id)}}">{{ face.officer.department.name|title }}</a></li>
+      <li><a href="{{url_for('main.officer_profile',officer_id=face.officer.id)}}">{{ face.officer.full_name()|title }}</a></li>
+      <li class="active">Tag {{ face.id }}</li>
+    </ol>
     <h1>Tag {{ face.id }} Detail</h1>
   </div>
 


### PR DESCRIPTION
## Description of Changes
Fixes #238. Add breadcrumbs to tag detail page

## Notes for Deployment
None!

## Screenshots (if appropriate)
![1](https://user-images.githubusercontent.com/66500457/200484253-a93a1f0b-d9bb-42ae-8a1d-a4e1e002f315.png)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
