### PR TITLE
Use department and serial to identify officers

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -128,12 +128,14 @@ class FindOfficerForm(Form):
 
 
 class FaceTag(Form):
-    officer_id = IntegerField("officer_id", validators=[DataRequired()])
-    image_id = IntegerField("image_id", validators=[DataRequired()])
+    department_id = IntegerField("department_id", validators=[InputRequired()])
+    star_no = IntegerField("star_no", validators=[InputRequired()])
+    image_id = IntegerField("image_id", validators=[InputRequired()])
     dataX = IntegerField("dataX", validators=[InputRequired()])
     dataY = IntegerField("dataY", validators=[InputRequired()])
     dataWidth = IntegerField("dataWidth", validators=[InputRequired()])
     dataHeight = IntegerField("dataHeight", validators=[InputRequired()])
+    officer_id = IntegerField("officer_id")
 
 
 class AssignmentForm(Form):

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -566,6 +566,10 @@ tr:hover .row-actions {
     display:block;
 }
 
+.docs-data .dept-input:hover ~ .input-explanation .dept-explanation{
+    display:block;
+}
+
 .docs-data .id-input:hover ~ .input-explanation .id-explanation{
     display:block;
 }

--- a/OpenOversight/app/templates/cop_face.html
+++ b/OpenOversight/app/templates/cop_face.html
@@ -76,11 +76,23 @@
                 <p><span style="color: red;">[{{ error }}]</span></p>
               {% endfor %}
 
-              <div class="input-group input-group-sm id-input">
-                <label class="input-group-addon" for="officer_id">OpenOversight ID</label>
-                <input type="text" class="form-control" name="officer_id" id="officer_id" placeholder="officer ID">
+              <div class="input-group input-group-sm dept-input">
+                {% if department %}
+                <input type="hidden" class="form-control" name="department_id" id="department_id" value="{{ department.id }}">
+                {% else %}
+                <label class="input-group-addon" for="department_id">Department id</label>
+                <input type="text" class="form-control" name="department_id" id="department_id" placeholder="department id">
+                {% endif %}
               </div>
-              {% for error in form.officer_id.errors %}
+              {% for error in form.department_id.errors %}
+                <p><span style="color: red;">[{{ error }}]</span></p>
+              {% endfor %}
+
+              <div class="input-group input-group-sm id-input">
+                <label class="input-group-addon" for="star_no">Officer serial number</label>
+                <input type="text" class="form-control" name="star_no" id="star_no" placeholder="officer serial number">
+              </div>
+              {% for error in form.star_no.errors %}
                 <p><span style="color: red;">[{{ error }}]</span></p>
               {% endfor %}
 
@@ -95,16 +107,15 @@
                 </div>
               </p>
 
-
-	      <div class="text-center input-explanation">
-		<div class="text addface-button-explanation"><b>Explanation</b>: click this button to associate the selected image with the entered OpenOversight ID.</div>
-		<div class="text id-explanation"><b>Explanation</b>: after matching the officer's name, badge number, or face to the roster, enter the officer's OpenOversight ID here.</div>
-	      </div>
-
-
+              <div class="text-center input-explanation">
+                <div class="text addface-button-explanation"><b>Explanation</b>: click this button to associate the selected image with the entered OpenOversight ID.</div>
+                <div class="text dept-explanation"><b>Explanation</b>: enter the ID for the department the officer belongs to here.</div>
+                <div class="text id-explanation"><b>Explanation</b>: enter the officer's serial number here.</div>
+              </div>
+            </form>
           </div>
-
         </div>
+
         <div class="col-sm-2 text-center skip-button">
           {% if department %}
           <a href="{{ url_for('main.label_data', department_id=department.id)}}" class="btn btn-lg btn-primary" role="button">
@@ -119,19 +130,18 @@
             All officers have been identified!
           </a>
         </div>
-	<hr>
 
-  <div class="row">
-    <div class="col-sm-12">
-      <div class="text-center button-explanation">
-        <div class="text done-button-explanation"><b>Explanation</b>: click this button ONLY when all officers in it have been identified. This will remove it from the identification queue for ALL users.</div>
-        <div class="text skip-button-explanation"><b>Explanation</b>: click this button if you would like to move on to the next image, without saving any info about this image.</div>
-        <div class="text launchroster-button-explanation"><b>Explanation</b>: click this button to open the police roster.  Use the roster to find the officer's OpenOversight ID.</div>
-      </div>
-    </div>
-  </div>
+        <hr>
 
-
+        <div class="row">
+          <div class="col-sm-12">
+            <div class="text-center button-explanation">
+              <div class="text done-button-explanation"><b>Explanation</b>: click this button ONLY when all officers in it have been identified. This will remove it from the identification queue for ALL users.</div>
+              <div class="text skip-button-explanation"><b>Explanation</b>: click this button if you would like to move on to the next image, without saving any info about this image.</div>
+              <div class="text launchroster-button-explanation"><b>Explanation</b>: click this button to open the police roster.  Use the roster to find the officer's OpenOversight ID.</div>
+            </div>
+          </div>
+        </div>
       </div>
 
 

--- a/OpenOversight/app/templates/cop_face_disambiguate.html
+++ b/OpenOversight/app/templates/cop_face_disambiguate.html
@@ -1,0 +1,116 @@
+{% extends "base.html" %}
+
+{% block head %}
+<style>
+.officer-select {
+    border: 1px solid transparent;
+    padding-top: 5px;
+    padding-bottom: 15px;
+}
+.officer-select, .officer-select img {
+    cursor: pointer;
+}
+.officer-select:hover {
+    border: 1px solid #d2d2d2;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="container theme-showcase" role="main">
+  {% if current_user and current_user.is_authenticated %}
+    {% if image_id and not current_user.is_disabled %}
+    <div class="row form-group">
+      <div class="col-sm-12">
+        <h2>Multiple officers found</h2>
+        <p>There are multiple officers in the {{department.name}} with the serial number {{ form.star_no.data }}. Which one did you mean?
+
+        <div>
+          {% if department %}
+          <form action="{{ url_for('main.label_data', image_id=image_id, department_id=department.id) }}" method="post">
+          {% else %}
+          <form action="{{ url_for('main.label_data', image_id=image_id) }}" method="post">
+          {% endif %}
+            {{ form.hidden_tag() }}
+
+            {{ form.dataX(type="hidden") }}
+            {% for error in form.dataX.errors %}
+              <p><span style="color: red;">[{{ error }}]</span></p>
+            {% endfor %}
+
+            {{ form.dataY(type="hidden") }}
+            {% for error in form.dataY.errors %}
+              <p><span style="color: red;">[{{ error }}]</span></p>
+            {% endfor %}
+
+            {{ form.dataWidth(type="hidden") }}
+            {% for error in form.dataWidth.errors %}
+              <p><span style="color: red;">[{{ error }}]</span></p>
+            {% endfor %}
+
+            {{ form.dataHeight(type="hidden") }}
+            {% for error in form.dataHeight.errors %}
+              <p><span style="color: red;">[{{ error }}]</span></p>
+            {% endfor %}
+
+            {{ form.department_id(type="hidden") }}
+            {% for error in form.department_id.errors %}
+              <p><span style="color: red;">[{{ error }}]</span></p>
+            {% endfor %}
+
+            {{ form.star_no(type="hidden") }}
+            {% for error in form.star_no.errors %}
+              <p><span style="color: red;">[{{ error }}]</span></p>
+            {% endfor %}
+
+            {{ form.image_id(type="hidden") }}
+            {% for error in form.image_id.errors %}
+              <p><span style="color: red;">[{{ error }}]</span></p>
+            {% endfor %}
+
+            <div class="row text-center well">
+              <fieldset>
+              {% for officer in officers %}
+                  <label class="col-sm-3 officer-select" for="officer-{{officer.id}}">
+                  <div>
+                      <img class="officer-face" src="{{ officer.image | default('/static/images/placeholder.png') }}" class="img-responsive thumbnail" alt="{{ officer.full_name() }}">
+                  </div>
+                  <div>
+                    <h2>
+                      <input id="officer-{{officer.id}}" name="officer_id" type="radio" value="{{officer.id}}">
+                      <a href="{{ url_for('main.officer_profile', officer_id=officer.id) }}" target="_blank">
+                          {{ officer.first_name}} {{ officer.last_name }}
+                      </a>
+                    </h2>
+                  </div>
+                </label>
+              {% endfor %}
+              </fieldset>
+
+              <br>
+
+              <input class="btn btn-primary btn-lg" type="submit" value="Submit!">
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div style="width: {{ form.dataWidth.data | int }}px; height: {{ form.dataHeight.data | int }}px; overflow: hidden; margin: auto">
+        <img style="position: relative; left: -{{ form.dataX.data | int }}px; top: -{{ form.dataY.data | int }}px; max-width: none" src="{{ path }}" alt="Picture">
+      </div>
+    </div>
+    {% elif current_user.is_disabled == True %}
+    <h3>Your account has been disabled due to too many incorrect classifications/tags!</h3>
+    <p><a href="mailto:techblocsea@protonmail.com" class="btn btn-lg btn-primary" role="button">Mail us to get it enabled again</a></p>
+    {% else %}
+    <h3>All images have been tagged!</h3>
+    <h4><small class="muted">{{ department.name }}</small></h4>
+    <p><a href="{{ url_for('main.submit_data')}}" class="btn btn-lg btn-primary" role="button">Submit officer pictures to us</a></p>
+    {% endif %}
+  {% endif %}
+</div>
+{% endblock %}
+
+{% block footer_class %}bottom-10{% endblock %}

--- a/OpenOversight/app/templates/cop_face_disambiguate.html
+++ b/OpenOversight/app/templates/cop_face_disambiguate.html
@@ -23,7 +23,7 @@
     <div class="row form-group">
       <div class="col-sm-12">
         <h2>Multiple officers found</h2>
-        <p>There are multiple officers in the {{department.name}} with the serial number {{ form.star_no.data }}. Which one did you mean?
+        <p>There are multiple officers in the {{ department.name }} with the serial number {{ form.star_no.data }}. Which one did you mean?
 
         <div>
           {% if department %}

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -314,6 +314,7 @@ def test_edit_officer_form_coerces_none_race_or_gender_to_not_sure(mockdata, bro
 def test_image_classification_and_tagging(mockdata, browser):
     test_dir = os.path.dirname(os.path.realpath(__file__))
     img_path = os.path.join(test_dir, "images/200Cat.jpeg")
+    star_no = 1312
 
     login_admin(browser)
 
@@ -335,6 +336,7 @@ def test_image_classification_and_tagging(mockdata, browser):
 
     browser.find_element(By.ID, "first_name").send_keys("Officer")
     browser.find_element(By.ID, "last_name").send_keys("Friendly")
+    browser.find_element(By.ID, "star_no").send_keys(star_no)
     browser.find_element(By.ID, "submit").click()
 
     wait_for_page_load(browser)
@@ -371,7 +373,7 @@ def test_image_classification_and_tagging(mockdata, browser):
     # 5. Identify the new officer in the uploaded image
     browser.get(f"http://localhost:5000/cop_face/department/{dept_id}")
     wait_for_page_load(browser)
-    browser.find_element(By.ID, "officer_id").send_keys(officer_id)
+    browser.find_element(By.ID, "star_no").send_keys(star_no)
     browser.find_element(By.CSS_SELECTOR, "input[value='Add identified face']").click()
 
     wait_for_page_load(browser)


### PR DESCRIPTION
## Description of Changes
Fixes #200.

* Change officer identification page to take department and serial instead of officer id
* Add page to disambiguate when multiple officers have the same serial

## Notes for Deployment
None!

## Screenshots (if appropriate)
Update officers to use the same serial number using this SQL statement:
```
openoversight=# update assignments set star_no = '1312' where officer_id in (50, 51, 52);
UPDATE 3
```

1. **`/cop_face/` (no department specified)**
![1](https://user-images.githubusercontent.com/66500457/205216808-cfaaa911-742f-4c91-ba07-3a2d9e73f087.png)

2. **`/cop_face/department/1/image/1` (with department specified)** - hides the department input
![2](https://user-images.githubusercontent.com/66500457/205216817-2541ec09-8e9a-400a-9a02-ce2eb95f2e37.png)

3. **Multiple officer disambiguation**
![3](https://user-images.githubusercontent.com/66500457/205216932-99f4a4e2-92a5-4caa-81c0-13e1eb47755a.png)

4. **Image tag saved**
![4](https://user-images.githubusercontent.com/66500457/205216948-b1bb72e3-0406-4a3a-bd76-c6d1a26aadc3.png)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
