### PR TITLE
Upgrade WTForms and use WTForms-SQLAlchemy

### DIFF
--- a/OpenOversight/app/auth/forms.py
+++ b/OpenOversight/app/auth/forms.py
@@ -6,8 +6,8 @@ from wtforms import (
     SubmitField,
     ValidationError,
 )
-from wtforms.ext.sqlalchemy.fields import QuerySelectField
 from wtforms.validators import DataRequired, Email, EqualTo, Length, Optional, Regexp
+from wtforms_sqlalchemy.fields import QuerySelectField
 
 from ..models import User
 from ..utils import dept_choices

--- a/OpenOversight/app/formfields.py
+++ b/OpenOversight/app/formfields.py
@@ -1,7 +1,7 @@
 import datetime
 
 from wtforms import StringField
-from wtforms.widgets.html5 import TimeInput
+from wtforms.widgets import TimeInput
 
 
 class TimeField(StringField):

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -15,8 +15,7 @@ from wtforms import (
     SubmitField,
     TextAreaField,
 )
-from wtforms.ext.sqlalchemy.fields import QuerySelectField
-from wtforms.fields.html5 import DateField
+from wtforms.fields import DateField
 from wtforms.validators import (
     URL,
     AnyOf,
@@ -28,6 +27,7 @@ from wtforms.validators import (
     Regexp,
     ValidationError,
 )
+from wtforms_sqlalchemy.fields import QuerySelectField
 
 from ..formfields import TimeField
 from ..models import Officer

--- a/OpenOversight/app/widgets.py
+++ b/OpenOversight/app/widgets.py
@@ -1,6 +1,5 @@
-from wtforms.compat import text_type
 from wtforms.fields import FormField
-from wtforms.widgets.core import HTMLString, ListWidget, html_params
+from wtforms.widgets.core import ListWidget, Markup, html_params
 
 
 class BootstrapListWidget(ListWidget):
@@ -29,7 +28,7 @@ class BootstrapListWidget(ListWidget):
                     % (subfield(), subfield.label)
                 )
         html.append("</%s>" % self.html_tag)
-        return HTMLString("".join(html))
+        return Markup("".join(html))
 
 
 class FormFieldWidget(object):
@@ -38,13 +37,13 @@ class FormFieldWidget(object):
         hidden = ""
         for subfield in field:
             if subfield.type == "HiddenField" or subfield.type == "CSRFTokenField":
-                hidden += text_type(subfield)
+                hidden += str(subfield)
             else:
                 html.append(
                     '<div class="form-group">%s %s %s</div>'
-                    % (text_type(subfield.label.text), hidden, text_type(subfield))
+                    % (str(subfield.label.text), hidden, str(subfield))
                 )
                 hidden = ""
         if hidden:
             html.append(hidden)
-        return HTMLString("".join(html))
+        return Markup("".join(html))

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,5 @@ python-dateutil==2.8.2
 python-dotenv==0.20.0
 SQLAlchemy==1.4.41
 us==2.0.2
-WTForms<3.0.0
+WTForms<4.0.0
+WTForms-SQLAlchemy==0.3


### PR DESCRIPTION
## Description of Changes
Fixes #245 and replaces #251 .

`wtforms.ext.sqlalchemy` was removed in WTForms 3.0 so a couple changes were needed before we could upgrade

## Notes for Deployment
None!

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
