### PR TITLE
Add github actions to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,10 @@ updates:
     labels:
       - "dependency"
       - "npm"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependency"
+      - "github-actions"


### PR DESCRIPTION
## Description of Changes

This adds the GitHub Actions to the list of things dependabot checks

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [ ] I have rebased my changes on `main`

 - [ ] `just lint` passes

 - [ ] `just test` passes
