### PR TITLE
Add a global ratelimit enable switch to application configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,5 @@ OO_MAIL_SENDER="Custom sender <admin@admin.com>"
 # Ideally shouldn't be needed in prod
 MAIL_DEBUG=False
 MAIL_SUPPRESS_SEND=False
+# Set this to "True" to disable rate limiting
+RATELIMIT_DISABLED=False

--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -49,7 +49,7 @@ class BaseConfig(object):
 
     # Rate limiting
     # https://flask-limiter.readthedocs.io/en/stable/configuration.html
-    RATELIMIT_ENABLED = os.environ.get("RATELIMIT_ENABLED", True)
+    RATELIMIT_ENABLED = not (os.environ.get("RATELIMIT_DISABLED", False) == "True")
 
     SEED = 666
 

--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -47,6 +47,10 @@ class BaseConfig(object):
     # https://flask-login.readthedocs.io/en/latest/#customizing-the-login-process
     USE_SESSION_FOR_NEXT = True
 
+    # Rate limiting
+    # https://flask-limiter.readthedocs.io/en/stable/configuration.html
+    RATELIMIT_ENABLED = os.environ.get("RATELIMIT_ENABLED", True)
+
     SEED = 666
 
     @staticmethod


### PR DESCRIPTION
## Description of Changes

This can be used for testing/disabling the rate limiting which is applied via flask-limiter. This adds the `RATELIMIT_DISABLED` environment variable which can be set to `True` for disabling rate limiting altogether.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [ ] `just lint` passes

 - [ ] `just test` passes
