### PR TITLE
Remove unused email-validator dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 Authlib==1.2.0
 boto3==1.26.144
 cachetools==5.3.1
-email-validator==1.3.0
 Fabric3==1.14.post1
 filetype==1.2.0
 Flask==2.2.2


### PR DESCRIPTION
## Description of Changes
`email-validator` was added as a dependency in [this commit](https://github.com/lucyparsons/OpenOversight/commit/33b87cc473092ef1bb95d3f47de1c9b93253a71b) but does not appear to ever have been used. This change removes the unused dependency.

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
