### PR TITLE
Fix NodeSource deprecation warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,13 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV DEBIAN-FRONTEND noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV PIP_NO_CACHE_DIR=1
-
-# Pin nodesource repo for nodejs
-# https://github.com/nodesource/distributions/issues/1579
-RUN echo "Package: nodejs" >> /etc/apt/preferences.d/nodesource && \
-    echo "Pin: origin deb.nodesource.com" >> /etc/apt/preferences.d/nodesource && \
-    echo "Pin-Priority: 600" >> /etc/apt/preferences.d/nodesource
+ENV NODE_MAJOR=16
 
 RUN apt-get update && \
-    apt-get install -y wget && \
-    wget -O - https://deb.nodesource.com/setup_16.x | bash - && \
+    apt-get install -y ca-certificates curl gnupg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
     apt-get install -y \
         gcc \


### PR DESCRIPTION
## Description of Changes
Fixes #359. Replaces NodeSource installation script with repository.

NodeSource added a 60 second delay to its installation script along with a deprecation warning banner. This change migrates to their new repository according to these instructions: https://github.com/nodesource/distributions#supported-versions

```
#9 3.472 ================================================================================
#9 3.472 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
#9 3.472 ================================================================================
#9 3.472 
#9 3.472                            SCRIPT DEPRECATION WARNING                    
#9 3.472 
#9 3.472   
#9 3.472   This script, located at https://deb.nodesource.com/setup_X, used to
#9 3.472   install Node.js is deprecated now and will eventually be made inactive.
#9 3.472 
#9 3.472   Please visit the NodeSource distributions Github and follow the
#9 3.472   instructions to migrate your repo.
#9 3.472   https://github.com/nodesource/distributions
#9 3.472 
#9 3.472   The NodeSource Node.js Linux distributions GitHub repository contains
#9 3.472   information about which versions of Node.js and which Linux distributions
#9 3.472   are supported and how to install it.
#9 3.472   https://github.com/nodesource/distributions
#9 3.472 
#9 3.472 
#9 3.472                           SCRIPT DEPRECATION WARNING
#9 3.472 
#9 3.472 ================================================================================
#9 3.472 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
#9 3.473 ================================================================================
#9 3.473 
#9 3.473 TO AVOID THIS WAIT MIGRATE THE SCRIPT
#9 3.473 Continuing in 60 seconds (press Ctrl-C to abort) ...
```

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
