### PR TITLE
Pin werkzeug to prevent breaking changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,6 @@ psycopg2-binary==2.9.5
 python-dateutil==2.8.2
 SQLAlchemy==2.0.19
 us==3.1.1
+werkzeug<3  # FIXME: Remove once flask is upgraded
 WTForms==3.0.1
 WTForms-SQLAlchemy==0.3


### PR DESCRIPTION
## Description of Changes

Quick fix for addressing an issue where an upstream dependency which is unpinned made breaking changes to existing deprecations.

https://github.com/pallets/flask/blob/3205b53c7cf69d17fee49cac6b84978175b7dd73/pyproject.toml#L22C6-L22C22
https://github.com/pallets/werkzeug/pull/2768/files#diff-342c3ac7878fc8165fb66b641c3a05ae0b4e5da5c9273fd00db272d61422bb89L1077

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
