### PR TITLE
Fix officer profile exception

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -310,7 +310,6 @@ def officer_profile(officer_id: int):
     form = AssignmentForm()
     try:
         officer = Officer.query.filter_by(id=officer_id).one()
-        officer.incidents.query.order_by(Incident.date.desc(), Incident.time.desc())
     except NoResultFound:
         abort(HTTPStatus.NOT_FOUND)
     except Exception:

--- a/OpenOversight/app/templates/partials/officer_incidents.html
+++ b/OpenOversight/app/templates/partials/officer_incidents.html
@@ -2,7 +2,7 @@
 {% if officer.incidents %}
   <table class="table table-hover table-responsive">
     <tbody>
-      {% for incident in officer.incidents %}
+      {% for incident in officer.incidents | sort(attribute='date') | reverse %}
         {% if not loop.first %}
           <tr class="border:none">
             <td colspan="2">&nbsp;</td>


### PR DESCRIPTION
## Description of Changes
Fixes #384.

Fixes the exception currently thrown while rendering officer profiles
```
web_1           | 2023-11-12 06:38:46,920 INFO sqlalchemy.engine.Engine [generated in 0.00029s] {'param_1': 848}                                                                       
web_1           | [2023-11-12 06:38:46,924] ERROR in views: Error finding officer                                                                                                      
web_1           | Traceback (most recent call last):                                                                                                                                   
web_1           |   File "/usr/src/app/OpenOversight/app/main/views.py", line 313, in officer_profile                                                                                  web_1           |     officer.incidents.query.order_by(Incident.date.desc(), Incident.time.desc())                                                                                     web_1           |     ^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                          
web_1           | AttributeError: 'InstrumentedList' object has no attribute 'query'
```

This partially reverts changes in https://github.com/lucyparsons/OpenOversight/pull/1056 which moved sorting from the template to the view function.

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and linting
No additional tests because the exception was being swallowed by the surrounding try-except but I checked the logs and made sure that the exception was present before my changes and was not after.

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
