### PR TITLE
Fix Sphinx docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,5 @@
 from typing import List, Tuple
 
-from recommonmark.parser import CommonMarkParser
-
 
 #
 # Configuration file for the Sphinx documentation builder.
@@ -30,7 +28,7 @@ release = ""
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["recommonmark"]
+extensions = ["myst_parser"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -41,10 +39,6 @@ templates_path = ["_templates"]
 source_suffix = {
     ".rst": "restructuredtext",
     ".md": "markdown",
-}
-
-source_parsers = {
-    ".md": CommonMarkParser,
 }
 
 # The master toctree document.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ Faker==19.3.1
 flake8==6.0.0
 ipython
 mypy==1.4.1
+myst-parser==2.0.0
 pandas>=0.23.4
 pre-commit==3.5.0
 pytest==7.3.1


### PR DESCRIPTION
## Description of Changes
Part of the upstream changes we pulled in added a dependency on recommonmark to add Markdown support for our Sphinx docs. Our docs build is currently failing because the recommonmark dependency wasn't added to our requirements.txt file as part of those changes.

Additionally, it looks like recommonmark [is now deprecated](https://github.com/readthedocs/recommonmark) and they recommend migrating to MyST.

This PR adds a dependency on MyST-Parser and configures Sphinx to use MyST.

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and linting
Ran `just make-docs && just serve-docs` and made sure docs still look as expected

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
