### PR TITLE
Fix Edit Department form

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -770,6 +770,7 @@ def edit_department(department_id: int):
         department.state = form.state.data
         department.last_updated_by = current_user.id
         db.session.flush()
+
         if form.jobs.data:
             new_ranks = []
             order = 1
@@ -826,8 +827,8 @@ def edit_department(department_id: int):
                             department_id=department_id,
                         )
                     )
-            db.session.commit()
 
+        db.session.commit()
         flash(f"Department {department.name} in {department.state} edited")
         return redirect(url_for("main.list_officer", department_id=department.id))
     else:

--- a/OpenOversight/app/templates/department_add_edit.html
+++ b/OpenOversight/app/templates/department_add_edit.html
@@ -35,7 +35,7 @@
           </div>
           <div class="text-danger">{{ wtf.form_errors(form.jobs, hiddens="only") }}</div>
           {% if form.jobs|length > 1 %}
-            {% for subfield in (form.jobs|rejectattr('data.is_sworn_officer','eq',False)|sort(attribute='data.order')|list) %}
+            {% for subfield in (form.jobs|sort(attribute='data.order')|list) %}
               <fieldset>
                 <div class="input-group {% if subfield.errors %} has-error{% endif -%} {%- if subfield.flags.required %} required{% endif -%}">
                   <div class="input-group-addon">


### PR DESCRIPTION
## Description of Changes
Fix #357:
1. Fix issue where changes were not committed if department did not have associated jobs
2. Fix "Add another rank" button 

This wasn't caught by our unit tests because the Flask test client is not triggering database session rollbacks between requests, meaning that uncommitted changes persisted across multiple requests.

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
