### PR TITLE
Fix issue where carousel controls were no longer showing up

### DIFF
--- a/OpenOversight/app/templates/partials/officer_faces.html
+++ b/OpenOversight/app/templates/partials/officer_faces.html
@@ -18,7 +18,7 @@
       </div>
     {% endfor %}
   </div>
-  {% if paths | length > 1 %}
+  {% if face_paths | length > 1 %}
     <a class="left carousel-control"
        href="#face-carousel"
        role="button"


### PR DESCRIPTION
## Description of Changes
The carousel controls are not showing up.

This was caused by a commit that changed `paths` to `face_paths`
https://github.com/lucyparsons/OpenOversight/pull/1070/files#diff-cb0d1be5137549bba7d2d657912ea708497d8a757e0623cb76d9d5557fe484e5

But the line controlling whether we show carousel controls is still using `paths`.
https://github.com/OrcaCollective/OpenOversight/blob/7bf658c8d431d2db12154ba5c90017d46f19cf14/OpenOversight/app/templates/partials/officer_faces.html#L21

This commit fixes this issue.

## Notes for Deployment
None!

## Screenshots (if appropriate)


## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
