### PR TITLE
Remove xvfb dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /usr/src/app
 
 # Install packages depending on ENV arg from docker-compose
 ARG BASE_PACKAGES="gcc libpq-dev libjpeg62-turbo-dev libsqlite3-0 zlib1g-dev"
-ARG DEV_PACKAGES="firefox-esr xvfb"
+ARG DEV_PACKAGES="firefox-esr"
 RUN if [ "$IS_PROD" = "true" ]; then \
         PACKAGES_TO_INSTALL="$BASE_PACKAGES"; \
     else \

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -20,7 +20,6 @@ from selenium.webdriver.firefox.service import Service as FirefoxService
 from selenium.webdriver.firefox.webdriver import WebDriver as Firefox
 from sqlalchemy.orm import scoped_session, sessionmaker
 from webdriver_manager.firefox import GeckoDriverManager
-from xvfbwrapper import Xvfb
 
 from OpenOversight.app import create_app
 from OpenOversight.app.models.database import (
@@ -901,12 +900,10 @@ def server(app, server_port):
 
 @pytest.fixture(scope="session")
 def browser(app, server):
-    # start headless webdriver
-    vdisplay = Xvfb()
-    vdisplay.start()
-
     options = FirefoxOptions()
-    options.headless = True
+    options.add_argument("--headless")
+    options.add_argument("--width=1024")
+    options.add_argument("--height=768")
 
     service = FirefoxService(
         executable_path=GeckoDriverManager().install(), log_path="/tmp/geckodriver.log"
@@ -917,4 +914,3 @@ def browser(app, server):
 
     # shutdown headless webdriver
     driver.quit()
-    vdisplay.stop()

--- a/poetry.lock
+++ b/poetry.lock
@@ -3222,17 +3222,7 @@ files = [
 SQLAlchemy = ">=0.7.10"
 WTForms = ">=1.0.5"
 
-[[package]]
-name = "xvfbwrapper"
-version = "0.2.9"
-description = "run headless display inside X virtual framebuffer (Xvfb)"
-optional = false
-python-versions = "*"
-files = [
-    {file = "xvfbwrapper-0.2.9.tar.gz", hash = "sha256:bcf4ae571941b40254faf7a73432dfc119ad21ce688f1fdec533067037ecfc24"},
-]
-
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "81c20fc287ac179d96829c6fb523140a29ccb6376f157a3cf40397857b4bd75e"
+content-hash = "2fea6410b13cb2bb11d56ec81921797d32580e4bc86fc98fe833d48816601c96"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ selenium = "4.17.2"
 sphinx = "7.0.1"
 sphinx-autobuild = "2021.3.14"
 webdriver-manager = "3.8.6"
-xvfbwrapper = "0.2.9"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Description of Changes
Remove xvfb dependency since we're using headless firefox

(This change depends on #411 and can be rebased once that PR has been merged)

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
