### PR TITLE
Set the preferred URL scheme in production to `https`

### DIFF
--- a/OpenOversight/app/models/config.py
+++ b/OpenOversight/app/models/config.py
@@ -101,6 +101,7 @@ class ProductionConfig(BaseConfig):
     def __init__(self):
         super(ProductionConfig, self).__init__()
         self.SITEMAP_URL_SCHEME = "https"
+        self.PREFERRED_URL_SCHEME = "https"
 
 
 config: dict[str, BaseConfig] = {


### PR DESCRIPTION
## Description of Changes

We are seeing an issue where calls to `url_for` using `_external=True` for certain conditions are generating links to files that include the scheme, but use `http` for it instead of `http`. This is causing a [mixed content warning](https://support.mozilla.org/en-US/kb/mixed-content-blocking-firefox?as=u&utm_source=inproduct&redirectslug=how-does-content-isnt-secure-affect-my-safety&redirectlocale=en-US) with our certificate. I tracked it down to pages that are serving the default placeholder image for officers, e.g.: https://github.com/OrcaCollective/OpenOversight/blob/6cd98570ef99486b44bf429c7a01ca89094a4c07/OpenOversight/app/templates/officer.html#L8.

![image](https://github.com/OrcaCollective/OpenOversight/assets/10214785/92897ac5-c957-43ff-a401-8f72c45c3314)

This PR changes the [`PREFERRED_URL_SCHEME` setting](https://flask.palletsprojects.com/en/2.3.x/config/#PREFERRED_URL_SCHEME) to `https` for production environments.

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
