### PR TITLE
Remove unnecessary external URL building for placeholder image

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -334,9 +334,7 @@ def officer_profile(officer_id: int):
             face_paths = [
                 (
                     None,
-                    url_for(
-                        "static", filename="images/placeholder.png", _external=True
-                    ),
+                    url_for("static", filename="images/placeholder.png"),
                 )
             ]
     except Exception:

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -146,9 +146,7 @@ def test_officer_appropriately_shows_placeholder(
 ):
     with current_app.test_request_context():
         officer = Officer.query.filter(filter_func(Officer.face.any())).first()
-        placeholder = url_for(
-            "static", filename="images/placeholder.png", _external=True
-        )
+        placeholder = url_for("static", filename="images/placeholder.png")
 
         rv = client.get(
             url_for("main.officer_profile", officer_id=officer.id),


### PR DESCRIPTION
## Description of Changes

I did an audit of usages of `url_for(..., _external=True)` in the project. All other uses are for JSON+LD definition of [breadcrumb elements](https://developers.google.com/search/docs/appearance/structured-data/breadcrumb) which probably explicitly require the full URL with scheme: 

https://github.com/OrcaCollective/OpenOversight/blob/6cd98570ef99486b44bf429c7a01ca89094a4c07/OpenOversight/app/templates/incident_detail.html#L12-L32

All other cases were for email generation which also need the full URL with scheme.
## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
