### PR TITLE
Fix content warning styles

### DIFF
--- a/OpenOversight/app/static/js/contentWarning.js
+++ b/OpenOversight/app/static/js/contentWarning.js
@@ -2,7 +2,7 @@ function createOverlay(container) {
     const warningText = $(
         "<span><h3>Content Warning</h3><p>This video may be disturbing for some viewers</p></span>"
     )
-    const hide = $('<button type="button" class="btn btn-lg">Show video</button>')
+    const hide = $('<button type="button" class="btn btn-lg btn-light">Show video</button>')
     hide.click(() => overlay.css("display", "none"))
 
     const wrapper = $("<div>")

--- a/OpenOversight/app/templates/partials/links_and_videos_row.html
+++ b/OpenOversight/app/templates/partials/links_and_videos_row.html
@@ -7,7 +7,7 @@
           <li class="list-group-item">
             <a href="{{ link.url }}" rel="noopener noreferrer" target="_blank">{{ link.title or link.url }}</a>
             {% if link.has_content_warning %}
-              <span class="label label-danger"
+              <span class="badge text-bg-danger"
                     title="The linked page may be disturbing for some viewers">Content Warning</span>
             {% endif %}
             {% if officer and (is_admin_or_coordinator or link.created_by == current_user.id) %}
@@ -83,7 +83,7 @@
           <li class="list-group-item">
             <a href="{{ link.url }}" target="_blank" rel="noopener noreferrer">{{ link.title or link.url }}</a>
             {% if link.has_content_warning %}
-              <span class="label label-danger"
+              <span class="badge text-bg-danger"
                     title="The linked video may be disturbing for some viewers">Content Warning</span>
             {% endif %}
             {% if officer and (current_user.is_admin_or_coordinator(officer.department)


### PR DESCRIPTION
## Description of Changes
Fix content warning styles

## Notes for Deployment
None!

## Screenshots (if appropriate)
![1](https://github.com/OrcaCollective/OpenOversight/assets/66500457/0efda517-5490-4ada-9fcc-2c57f17b457b)


## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
