### PR TITLE
Add `db stamp` to `fresh-start` recipe

### DIFF
--- a/OpenOversight/app/templates/add_officer.html
+++ b/OpenOversight/app/templates/add_officer.html
@@ -54,7 +54,7 @@
           {% endfor %}
           <button class="btn btn-success js-add-another-button" disabled>Add another description</button>
         </div>
-        <div class="mt-3">{{ wtf.render_field(form.submit, id="submit", button_map={'submit':'primary'}) }}</div>
+        {{ wtf.render_field(form.submit, id="submit", button_map={'submit':'primary'}) }}
       </form>
       <br>
     </div>

--- a/OpenOversight/app/templates/add_officer.html
+++ b/OpenOversight/app/templates/add_officer.html
@@ -54,7 +54,7 @@
           {% endfor %}
           <button class="btn btn-success js-add-another-button" disabled>Add another description</button>
         </div>
-        {{ wtf.render_field(form.submit, id="submit", button_map={'submit':'primary'}) }}
+        <div class="mt-3">{{ wtf.render_field(form.submit, id="submit", button_map={'submit':'primary'}) }}</div>
       </form>
       <br>
     </div>

--- a/justfile
+++ b/justfile
@@ -60,14 +60,14 @@ fresh-start:
 	@just down -v
 	@just build
 
-	# Start up and populate fields
+	# Prepare the database
 	{{ RUN_WEB }} python create_db.py
+	@just db stamp
+
+	# Populate users and data
 	{{ RUN_WEB }} flask make-admin-user
 	{{ RUN_WEB }} flask add-department "Seattle Police Department" "SPD" "WA"
 	{{ RUN_WEB }} flask bulk-add-officers /data/init_data.csv
-
-	# Stamp the database
-	@just db stamp
 
 	# Start containers
 	@just up

--- a/justfile
+++ b/justfile
@@ -94,7 +94,7 @@ lock:
 
 # Run Flask-Migrate tasks in the web container
 db +migrateargs:
-    just run --no-deps web flask db {{ migrateargs }}
+    just run web flask db {{ migrateargs }}
 
 # Run unit tests in the web container
 test *pytestargs:

--- a/justfile
+++ b/justfile
@@ -62,7 +62,7 @@ fresh-start:
 
 	# Prepare the database
 	{{ RUN_WEB }} python create_db.py
-	@just db stamp
+	{{ RUN_WEB }} flask db stamp
 
 	# Populate users and data
 	{{ RUN_WEB }} flask make-admin-user

--- a/justfile
+++ b/justfile
@@ -66,6 +66,9 @@ fresh-start:
 	{{ RUN_WEB }} flask add-department "Seattle Police Department" "SPD" "WA"
 	{{ RUN_WEB }} flask bulk-add-officers /data/init_data.csv
 
+	# Stamp the database
+	@just db stamp
+
 	# Start containers
 	@just up
 


### PR DESCRIPTION
## Description of Changes

Stamps the database as part of `fresh-start` to ensure we can run migrations more easily (i.e. without extra steps).

Run `just fresh-start` and observe something along the following happening near the end:

```
# Stamp the database
just run --no-deps web flask db stamp
docker-compose --file=docker-compose.yml --file=docker-compose.dev.yml run --rm "$@"
[2024-06-22 23:42:26,406] INFO in __init__: OpenOversight startup
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running stamp_revision  -> 939ea0f2b26d
```

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
