### PR TITLE
Run `dotenv` recipe before `fresh-start`

### DIFF
--- a/justfile
+++ b/justfile
@@ -55,7 +55,7 @@ deploy:
     @just up
 
 # Tear down the database, remove the volumes, recreate the database, and populate it with sample data
-fresh-start:
+fresh-start: dotenv
 	# Tear down existing containers, remove volume
 	@just down -v
 	@just build


### PR DESCRIPTION
## Description of Changes

Fixes #462

Although `dotenv` is a dependency for the `just build` recipe, the `fresh-start` recipe will attempt to run `just down -v` first, which will fail if a `.env` file isn't available:

```bash
$ j fresh-start 
# Tear down existing containers, remove volume
docker-compose --file=docker-compose.yml --file=docker-compose.dev.yml down -v
WARN[0000] The "MINIO_ROOT_PASSWORD" variable is not set. Defaulting to a blank string. 
WARN[0000] The "S3_BUCKET_NAME" variable is not set. Defaulting to a blank string. 
WARN[0000] The "S3_BUCKET_NAME" variable is not set. Defaulting to a blank string. 
Failed to load /home/madison/git/OpenOversight/.env: open /home/madison/git/OpenOversight/.env: no such file or directory
error: Recipe `down` failed on line 41 with exit code 14
error: Recipe `fresh-start` failed on line 60 with exit code 14
```

This PR adds `dotenv` as a dependency for `fresh-start` to ensure that it gets run every time, so new contributors [directed to run it first](https://github.com/OrcaCollective/OpenOversight/blob/8e5bc8dac3bfb1439bc8c21812daf32e22ba7dcd/README.md#L18-L17) don't encounter an issue.

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
