### PR TITLE
Use docker's "compose" command rather than docker-compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.2"
-
 services:
   postgres:
     ports:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: "3.2"
-
 services:
   web:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.2"
-
 services:
   postgres:
     restart: always

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ COMPOSE_FILE := "--file=docker-compose.yml" + (
     if IS_PROD == "true" {" --file=docker-compose.prod.yml"}
     else {" --file=docker-compose.dev.yml"}
 )
-DC := "docker-compose " + COMPOSE_FILE
+DC := "docker compose " + COMPOSE_FILE
 RUN := DC + " run --rm"
 RUN_WEB := RUN + " web"
 set dotenv-load := false


### PR DESCRIPTION
## Description of Changes

Fixes #463 (at least for the `justfile` which is what we primarily use). This changes calls from the `docker-compose` plugin to docker's `compose` command directly (`docker compose`). I also removed the `version` argument which was throwing these warnings:

```
$ j build
docker compose --file=docker-compose.yml --file=docker-compose.dev.yml build
WARN[0000] /home/madison/git/OpenOversight/docker-compose.yml: `version` is obsolete 
WARN[0000] /home/madison/git/OpenOversight/docker-compose.dev.yml: `version` is obsolete 
```

## Notes for Deployment

None

## Screenshots (if appropriate)

N/A

## Tests and linting

To test, try running `just build` locally and make sure you don't see the warnings and that the containers should be built appropriately.

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
