### PR TITLE
Add prompt bypass option for `bulk-add-officers` command

### DIFF
--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -469,8 +469,17 @@ def process_salary(row, officer, compare=False):
     is_flag=True,
     help="allow updating normally-static fields like race, birth year, etc.",
 )
+@click.option(
+    "--yes",
+    "-y",
+    "bypass_prompt",
+    is_flag=True,
+    help="bypass the user prompt and immediately add the officers to the database",
+)
 @with_appcontext
-def bulk_add_officers(filename, no_create, update_by_name, update_static_fields):
+def bulk_add_officers(
+    filename, no_create, update_by_name, update_static_fields, bypass_prompt
+):
     """Add or update officers from a CSV file."""
 
     encoding = ENCODING_UTF_8
@@ -551,8 +560,10 @@ def bulk_add_officers(filename, no_create, update_by_name, update_static_fields)
                 create_officer_from_row(row, department_id)
 
         ImportLog.print_logs()
-        if current_app.config["ENV"] == "testing" or prompt_yes_no(
-            "Do you want to commit the above changes?"
+        if (
+            current_app.config["ENV"] == "testing"
+            or bypass_prompt
+            or prompt_yes_no("Do you want to commit the above changes?")
         ):
             print("Commiting changes.")
             db.session.commit()

--- a/justfile
+++ b/justfile
@@ -64,7 +64,7 @@ fresh-start: dotenv
 	{{ RUN_WEB }} python create_db.py
 	{{ RUN_WEB }} flask make-admin-user
 	{{ RUN_WEB }} flask add-department "Seattle Police Department" "SPD" "WA"
-	{{ RUN_WEB }} flask bulk-add-officers /data/init_data.csv
+	{{ RUN_WEB }} flask bulk-add-officers -y /data/init_data.csv
 
 	# Start containers
 	@just up


### PR DESCRIPTION
## Description of Changes

Fixes #222

This PR adds a `--yes`/`-y` option for the `bulk-add-officers` command so that the prompt for confirming an insert can be skipped outside of the testing environment.

This has been added to the `fresh-start` command so that it continues on its own without input at that step.

## Notes for Deployment

None

## Screenshots (if appropriate)

N/A

## Tests and linting

Run `just fresh-start` and observe that it continues after the admin account prompt on its own

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
