### PR TITLE
Add no-input options for `make-admin-user` command

### DIFF
--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -33,11 +33,33 @@ from OpenOversight.app.utils.general import normalize_gender, prompt_yes_no, str
 
 
 @click.command()
+@click.option(
+    "-u",
+    "--username",
+    "supplied_username",
+    help="username for the admin account",
+)
+@click.option(
+    "-e",
+    "--email",
+    "supplied_email",
+    help="email for the admin account",
+)
+@click.option(
+    "-p",
+    "--password",
+    "supplied_password",
+    help="password for the admin account",
+)
 @with_appcontext
-def make_admin_user():
+def make_admin_user(
+    supplied_username: str | None,
+    supplied_email: str | None,
+    supplied_password: str | None,
+):
     """Add confirmed administrator account."""
     while True:
-        username = input("Username: ")
+        username = supplied_username or input("Username: ")
         user = User.by_username(username).one_or_none()
         if user:
             print("Username is already in use")
@@ -45,7 +67,7 @@ def make_admin_user():
             break
 
     while True:
-        email = input("Email: ")
+        email = supplied_email or input("Email: ")
         user = User.by_email(email).one_or_none()
         if user:
             print("Email address already in use")
@@ -53,8 +75,8 @@ def make_admin_user():
             break
 
     while True:
-        password = getpass("Password: ")
-        password_again = getpass("Type your password again: ")
+        password = supplied_password or getpass("Password: ")
+        password_again = supplied_password or getpass("Type your password again: ")
 
         if password == password_again:
             break

--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -58,29 +58,38 @@ def make_admin_user(
     supplied_password: str | None,
 ):
     """Add confirmed administrator account."""
-    while True:
-        username = supplied_username or input("Username: ")
-        user = User.by_username(username).one_or_none()
-        if user:
-            print("Username is already in use")
-        else:
-            break
+    if supplied_username:
+        username = supplied_username
+    else:
+        while True:
+            username = input("Username: ")
+            user = User.by_username(username).one_or_none()
+            if user:
+                print("Username is already in use")
+            else:
+                break
 
-    while True:
-        email = supplied_email or input("Email: ")
-        user = User.by_email(email).one_or_none()
-        if user:
-            print("Email address already in use")
-        else:
-            break
+    if supplied_email:
+        email = supplied_email
+    else:
+        while True:
+            email = input("Email: ")
+            user = User.by_email(email).one_or_none()
+            if user:
+                print("Email address already in use")
+            else:
+                break
 
-    while True:
-        password = supplied_password or getpass("Password: ")
-        password_again = supplied_password or getpass("Type your password again: ")
+    if supplied_password:
+        password = supplied_password
+    else:
+        while True:
+            password = getpass("Password: ")
+            password_again = getpass("Type your password again: ")
 
-        if password == password_again:
-            break
-        print("Passwords did not match")
+            if password == password_again:
+                break
+            print("Passwords did not match")
 
     u = User(
         username=username,

--- a/README.md
+++ b/README.md
@@ -15,12 +15,11 @@ This repository represents the **Seattle fork** of the original project. For mor
 
 To run the project locally:
 1. [Install `just`](https://github.com/casey/just)
-2. Run `just fresh-start` to spin up the database and insert the initial data. **This will prompt you for information to create a local super-admin user.** Enter this information for the following fields:
+2. Run `just fresh-start` to spin up the database and insert the initial data. **This will create a local super-admin user for you** with the following information:
    1. `Username`: `admin`
    2. `Email`: `admin@admin.com`
    3. `Password`: `admin`
-   4. `Commit changes?`: `y`
-3. Run `just up` and visit http://localhost:3000!
+3. Visit http://localhost:3000!
 
 To re-generate the poetry lock file (if you need to update dependencies in pyproject.toml):
 1. Run `just lock`

--- a/justfile
+++ b/justfile
@@ -65,7 +65,7 @@ fresh-start: dotenv
 	{{ RUN_WEB }} flask db stamp
 
 	# Populate users and data
-	{{ RUN_WEB }} flask make-admin-user
+	{{ RUN_WEB }} flask make-admin-user --username admin --email admin@admin.com --password admin
 	{{ RUN_WEB }} flask add-department "Seattle Police Department" "SPD" "WA"
 	{{ RUN_WEB }} flask bulk-add-officers -y /data/init_data.csv
 


### PR DESCRIPTION
## Description of Changes

Fixes #221

This PR adds some CLI options for the `make-admin-user` command which allows the username, email, and password of the admin account to be specified. This makes it easier to run the command without prompting for any inputs, as is done in the `just fresh-start` recipe.

## Notes for Deployment

None

## Screenshots (if appropriate)

N/A

## Tests and linting

Run `just fresh-start` locally and note how the admin creation account step!

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
