### PR TITLE
Add "testing instructions" section to PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,9 @@
 
 ## Screenshots (if appropriate)
 
-## Tests and linting
+## Testing instructions
+
+## Checks
 
  - [ ] I have rebased my changes on `main`
 


### PR DESCRIPTION
## Description of Changes

This PR changes the default pull request template to add a "testing instructions" section (and renames the "tests and linting" to "checks"). The testing section is intended to provide a way for the PR author to communicate how to appropriately test the changes supplied in the PR.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [ ] I have rebased my changes on `main`

 - [ ] `just lint` passes

 - [ ] `just test` passes
