### PR TITLE
Fix `just` default recipe invocation

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ set positional-arguments
 
 
 default:
-    @just -lu
+    @just -ul
 
 # Create the .env file from the template
 dotenv:


### PR DESCRIPTION
## Description of Changes

Newer versions of `just` allow the `--list` option (`-l`) to specify arguments after it. This is a breaking change for us, as now the `--unsorted` argument (`-u`) immediately following it is misread as a submodule. This PR fixes this issue by rearranging the arguments for the default recipe.

## Testing instructions

Check out the main branch, and run `just` in the repo. You should see the following:

```bash
$ just
error: Justfile does not contain submodule `u`
```

Then check out this branch and run `just`. You should see all the recipes listed instead.

## Checks

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
