### PR TITLE
Unify FROM/AS casing for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.5-slim as base
+FROM python:3.12.5-slim AS base
 ARG IS_PROD
 ENV DEBIAN_FRONTEND noninteractive
 ENV PIP_NO_CACHE_DIR=1

--- a/OpenOversight/app/templates/department_add_edit.html
+++ b/OpenOversight/app/templates/department_add_edit.html
@@ -58,7 +58,7 @@
               </div>
             </fieldset>
           {% endif %}
-          <button class="btn btn-success js-add-another-button" disabled>Add another rank</button>
+          <button class="btn btn-success js-add-another-button mb-1" disabled>Add another rank</button>
         </div>
         {{ wtf.render_field(form.submit, id="submit", button_map={'submit':'primary'}) }}
       </form>

--- a/OpenOversight/app/templates/department_add_edit.html
+++ b/OpenOversight/app/templates/department_add_edit.html
@@ -58,7 +58,7 @@
               </div>
             </fieldset>
           {% endif %}
-          <button class="btn btn-success js-add-another-button mb-1" disabled>Add another rank</button>
+          <button class="btn btn-success js-add-another-button" disabled>Add another rank</button>
         </div>
         {{ wtf.render_field(form.submit, id="submit", button_map={'submit':'primary'}) }}
       </form>

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -351,7 +351,11 @@ def test_image_classification_and_tagging(mockdata, browser, server_port):
     browser.find_element(By.ID, "name").send_keys("Auburn Police Department")
     browser.find_element(By.ID, "short_name").send_keys("APD")
     Select(browser.find_element(By.ID, "state")).select_by_value("WA")
-    browser.find_element(By.ID, "submit").click()
+
+    submit = browser.find_element(By.ID, "submit")
+    scroll_to_element(browser, submit)
+    submit.click()
+
     wait_for_page_load(browser)
 
     # 2. Add a new officer
@@ -452,7 +456,11 @@ def test_anonymous_user_can_upload_image(mockdata, browser, server_port):
     browser.find_element(By.ID, "name").send_keys("Auburn Police Department")
     browser.find_element(By.ID, "short_name").send_keys("APD")
     Select(browser.find_element(By.ID, "state")).select_by_value("WA")
-    browser.find_element(By.ID, "submit").click()
+
+    submit = browser.find_element(By.ID, "submit")
+    scroll_to_element(browser, submit)
+    submit.click()
+
     wait_for_page_load(browser)
 
     # 2. Log out


### PR DESCRIPTION
## Description of Changes

This PR fixes the following warning that was showing up during `just build`:

```
docker compose --file=docker-compose.yml --file=docker-compose.dev.yml build
[+] Building 1.1s (14/14) FINISHED                                                                                                                                                                                                                                         docker:default
 => [web internal] load build definition from Dockerfile                                                                                                                                                                                                                             0.0s
 => => transferring dockerfile: 1.26kB                                                                                                                                                                                                                                               0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                                                                                                                                                                                       0.0s
 => [web internal] load metadata for docker.io/library/python:3.12.5-slim                                                                                                                                                                                                            0.7s
 => [web internal] load .dockerignore                                                
```

## Testing instructions

Run `just build` and ensure the warning no longer shows up

## Checks

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
