### PR TITLE
Fix department selector on submit image page

### DIFF
--- a/OpenOversight/app/models/config.py
+++ b/OpenOversight/app/models/config.py
@@ -96,6 +96,11 @@ class TestingConfig(BaseConfig):
         self.NUM_OFFICERS = 120
         self.RATELIMIT_ENABLED = False
         self.SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+        # Disable sqlite cached statements
+        # https://github.com/python/cpython/issues/118172
+        self.SQLALCHEMY_ENGINE_OPTIONS = {
+            "connect_args": {"cached_statements": 0},
+        }
 
 
 class ProductionConfig(BaseConfig):

--- a/OpenOversight/app/templates/submit_image.html
+++ b/OpenOversight/app/templates/submit_image.html
@@ -76,19 +76,15 @@
     <script src="{{ url_for('static', filename='js/dropzone.js') }}"></script>
     <script src="{{ url_for('static', filename='js/init-dropzone.js') }}"></script>
     <script>
-        // Select user's preferred department by default
-        document.getElementById("department").selectedIndex = {{ preferred_dept_id }} - 1;
-        // Save the preferred department in dept_id
-        let dept_id = document.getElementById("department").selectedIndex + 1;
         const csrf_token = "{{ csrf_token() }}";
 
-        // Store changes in drop down list in dept_id variable
-        $(function() {
-            const select_dept = $('#dept-select');
-            select_dept.on('change', function() {
-                // fires when department selection changes
-                dept_id = document.getElementById("department").value;
-            });
+        // Select user's preferred department by default
+        let dept_id = {{ preferred_dept_id }};
+        $("#department").val(dept_id);
+
+        // Store drop down list changes in dept_id variable
+        $("#dept-select").on('change', function() {
+            dept_id = $("#department").val();
         });
 
         const getURL = (file) => "/upload/department/" + dept_id;


### PR DESCRIPTION
## Description of Changes
Fix bug where submit image page department selector was not submitting images to the correct department.

It looks like the current implementation was using `selectedIndex` (the index of the selected `<option>` element in the `<select>`) as the initial department id, which assumes the departments are loaded in order:

https://github.com/OrcaCollective/OpenOversight/blob/2c5ad9a74687943eac5e71a874c0f4ceb4784fa0/OpenOversight/app/templates/submit_image.html#L79-L82

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Testing instructions
1. Log in as admin user.
2. Create a new department "Bellevue Police Department (BPD)" at http://localhost:3000/departments/new.
3. Update the preferred department to BPD at http://localhost:3000/auth/change-dept/.
4. Go to the Submit Image page (http://localhost:3000/submit) and confirm that the populated department is BPD.
5. Upload an image.
6. Verify in devtools that an image was submitted to http://localhost:3000/upload/departments/2.
7. Update the department selector to SPD.
8. Upload an image.
9. Verify in devtools that an image was submitted to http://localhost:3000/upload/departments/1.
10. Change the preferred department to SPD at http://localhost:3000/auth/change-dept/.
11. Go to the Submit Image page (http://localhost:3000/submit) and confirm that the populated department is now SPD.
12. Upload an image.
13. Verify in devtools that an image was submitted to http://localhost:3000/upload/departments/1.

## Checks

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
