### PR TITLE
🚀 Upgrade database during deployments

### DIFF
--- a/justfile
+++ b/justfile
@@ -48,11 +48,9 @@ logs *args:
 pull:
     {{ DC }} pull
 
-# Pull and deploy all images
-deploy:
+# Pull, migrate, and deploy all images
+deploy: && pull (db "upgrade") up
     -git pull
-    @just pull
-    @just up
 
 # Tear down the database, remove the volumes, recreate the database, and populate it with sample data
 fresh-start: dotenv


### PR DESCRIPTION
## Description of Changes

More than once now, I've deploy this service (via `just deploy`) and forgotten to run a database migration, which has caused the app to break.

This PR modifies the `just deploy` script so that it pulls the image, runs `just db migrate`, then restarts the stack automatically.

## Notes for Deployment

## Screenshots (if appropriate)

## Testing instructions

Run `just deploy` locally.

## Checks

 - [ ] I have rebased my changes on `main`

 - [ ] `just lint` passes

 - [ ] `just test` passes
