### PR TITLE
Fix deprecated `mc` call, add more logging on CI failure

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,9 +25,7 @@ jobs:
       - name: Run tests
         run: |
           just build
-          just down -v
           just up
-          sleep 3
           just test
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Run tests
         run: |
           just build
+          just down -v
           just up
+          sleep 3
           just test
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,4 +37,4 @@ jobs:
       - if: ${{ failure() }}
         name: Print logs
         run: |
-          docker compose logs
+          FOLLOW_LOGS='' just logs

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,4 +37,4 @@ jobs:
       - if: ${{ failure() }}
         name: Print logs
         run: |
-          docker compost logs
+          docker compose logs

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,3 +34,10 @@ jobs:
         with:
           name: playwright-traces
           path: build/test-results/
+      - if: ${{ failure() }}
+        name: Print logs
+        run: |
+          echo "Minio logs:"
+          docker logs minio || true
+          echo "Postgres logs:"
+          docker logs postgres || true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,6 +38,8 @@ jobs:
         name: Print logs
         run: |
           echo "Minio logs:"
-          docker logs minio || true
+          docker compose logs minio || true
+          echo "Createbucket logs:"
+          docker compose logs createbucket || true
           echo "Postgres logs:"
-          docker logs postgres || true
+          docker compose logs postgres || true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,9 +37,4 @@ jobs:
       - if: ${{ failure() }}
         name: Print logs
         run: |
-          echo "Minio logs:"
-          docker compose logs minio || true
-          echo "Createbucket logs:"
-          docker compose logs createbucket || true
-          echo "Postgres logs:"
-          docker compose logs postgres || true
+          docker compost logs

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,7 +31,7 @@ services:
     entrypoint: >
       /bin/sh -c "
       sleep 5;
-      /usr/bin/mc config host add myminio http://minio:9000 minio ${MINIO_ROOT_PASSWORD};
+      /usr/bin/mc alias set myminio http://minio:9000 minio ${MINIO_ROOT_PASSWORD};
       /usr/bin/mc mb myminio/${S3_BUCKET_NAME};
       /usr/bin/mc anonymous set public myminio/${S3_BUCKET_NAME};
       exit 0;

--- a/justfile
+++ b/justfile
@@ -6,6 +6,7 @@ COMPOSE_FILE := "--file=docker-compose.yml" + (
 DC := "docker compose " + COMPOSE_FILE
 RUN := DC + " run --rm"
 RUN_WEB := RUN + " web"
+FOLLOW_LOGS := env("FOLLOW_LOGS", "-f")
 set dotenv-load := false
 # Force just to hand down positional arguments so quoted arguments with spaces are
 # handled appropriately
@@ -42,7 +43,7 @@ down *args:
 
 # Attach logs to all (or the specified) services
 logs *args:
-	{{ DC }} logs -f {{ args }}
+	{{ DC }} logs {{ FOLLOW_LOGS }} {{ args }}
 
 # Pull all docker images
 pull:


### PR DESCRIPTION
## Description of Changes

We've had some recent failures in the CI that looked like they were the result of Minio-related issues. This PR adds some additional debug tooling for the future, as well as addresses the underlying issue which is replacing `mc config host add` with `mc alias set`. 

See: https://github.com/minio/minio/issues/21327#issuecomment-2915017349

## Notes for Deployment

## Screenshots (if appropriate)

## Testing instructions

- Run `just pull` and then `just up && just test` on `main`, and you should see the issue occur
- Running the same on this branch should let all tests pass!

## Checks

 - [ ] I have rebased my changes on `main`

 - [ ] `just lint` passes

 - [ ] `just test` passes
