### PR TITLE
Run CI on main merges, add Docker caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3
+
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Cache Docker layers
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          # Use a hash of any files that affect the Docker build context
+          key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile', 'docker-compose*.yml', 'poetry.lock', 'pyproject.toml') }}
+          # Fallback to a more generic key if the specific one is not found
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Run tests
         run: |
           just build
           just up
           just test
+
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,12 @@
 name: Lint and Test
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
-
   static-checks:
     runs-on: ubuntu-latest
     steps:
@@ -32,7 +35,7 @@ jobs:
         with:
           name: playwright-traces
           path: build/test-results/
-      - if: ${{ failure() }}
+      - if: ${{ failure() && github.event_name == 'pull_request' }}
         name: Print logs
         run: |
           FOLLOW_LOGS='' just logs


### PR DESCRIPTION
## Description of Changes

This PR makes two separate changes

- Ensures CI gets run on main after a merge, so even if a PR is merged months after a successful CI run, a merge to main still ensures that PR is viable
- Adds caching to the Docker build layers for faster build times

## Notes for Deployment

## Screenshots (if appropriate)

## Testing instructions

## Checks

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
